### PR TITLE
Fix keyset paging for desc order and multiple sort keys

### DIFF
--- a/src/JoinMonster/Builders/SortKeyBuilder.cs
+++ b/src/JoinMonster/Builders/SortKeyBuilder.cs
@@ -25,18 +25,20 @@ namespace JoinMonster.Builders
         /// Sort the result by the <paramref name="column"/> in ascending order.
         /// </summary>
         /// <param name="column">The column name.</param>
-        public ThenSortKeyBuilder By(string column) => By(column, SortDirection.Ascending);
+        /// <param name="whereColumn">The column name used for the where clause.</param>
+        public ThenSortKeyBuilder By(string column, string? whereColumn = null) => By(column, whereColumn, SortDirection.Ascending);
 
 
         /// <summary>
         /// Sort the result by the <paramref name="column"/> in descending order.
         /// </summary>
         /// <param name="column">The column name.</param>
-        public ThenSortKeyBuilder ByDescending(string column) => By(column, SortDirection.Descending);
+        /// <param name="whereColumn">The column name used for the where clause.</param>
+        public ThenSortKeyBuilder ByDescending(string column, string? whereColumn = null) => By(column, whereColumn, SortDirection.Descending);
 
-        private ThenSortKeyBuilder By(string column, SortDirection direction)
+        private ThenSortKeyBuilder By(string column, string? whereColumn, SortDirection direction)
         {
-            SortKey = new SortKey(Table, column, _aliasGenerator.GenerateColumnAlias(column), direction);
+            SortKey = new SortKey(Table, column, whereColumn, _aliasGenerator.GenerateColumnAlias(column), direction);
             return new ThenSortKeyBuilder(Table, SortKey, _aliasGenerator);
         }
     }
@@ -62,18 +64,20 @@ namespace JoinMonster.Builders
         /// Sort the result by the <paramref name="column"/> in ascending order.
         /// </summary>
         /// <param name="column">The column name.</param>
-        public ThenSortKeyBuilder ThenBy(string column) => ThenBy(column, SortDirection.Ascending);
+        /// <param name="whereColumn">The column name used for the where clause.</param>
+        public ThenSortKeyBuilder ThenBy(string column, string? whereColumn = null) => ThenBy(column, whereColumn, SortDirection.Ascending);
 
 
         /// <summary>
         /// Sort the result by the <paramref name="column"/> in descending order.
         /// </summary>
         /// <param name="column">The column name.</param>
-        public ThenSortKeyBuilder ThenByDescending(string column) => ThenBy(column, SortDirection.Descending);
+        /// <param name="whereColumn">The column name used for the where clause.</param>
+        public ThenSortKeyBuilder ThenByDescending(string column, string? whereColumn = null) => ThenBy(column, whereColumn, SortDirection.Descending);
 
-        private ThenSortKeyBuilder ThenBy(string column, SortDirection direction)
+        private ThenSortKeyBuilder ThenBy(string column, string? whereColumn, SortDirection direction)
         {
-            SortKey.ThenBy = new SortKey(Table, column, _aliasGenerator.GenerateColumnAlias(column), direction);
+            SortKey.ThenBy = new SortKey(Table, column, whereColumn, _aliasGenerator.GenerateColumnAlias(column), direction);
             return new ThenSortKeyBuilder(Table, SortKey.ThenBy, _aliasGenerator);
         }
     }

--- a/src/JoinMonster/Language/AST/SortKey.cs
+++ b/src/JoinMonster/Language/AST/SortKey.cs
@@ -5,16 +5,18 @@ namespace JoinMonster.Language.AST
 {
     public class SortKey
     {
-        public SortKey(string table, string column, string @as, SortDirection direction)
+        public SortKey(string table, string column, string? whereColumn, string @as, SortDirection direction)
         {
             Table = table ?? throw new ArgumentNullException(nameof(table));
             Column = column ?? throw new ArgumentNullException(nameof(column));
+            WhereColumn = whereColumn ?? column;
             As = @as ?? throw new ArgumentNullException(nameof(@as));
             Direction = direction;
         }
 
         public string Table { get; }
         public string Column { get; }
+        public string WhereColumn { get; }
         public string As { get; }
         public SortDirection Direction { get; }
         public SortKey? ThenBy { get; set; }

--- a/src/JoinMonster/Language/QueryToSqlConverter.cs
+++ b/src/JoinMonster/Language/QueryToSqlConverter.cs
@@ -206,7 +206,7 @@ namespace JoinMonster.Language
                 do
                 {
 
-                    var newChild = new SqlColumn(sqlTable, sortKey.Column, sortKey.Column, sortKey.As);
+                    var newChild = new SqlColumn(sqlTable, sortKey.WhereColumn, sortKey.Column, sortKey.As);
                     if (sqlTable.SortKey == null && sqlTable.Junction != null)
                         newChild.FromOtherTable = sqlTable.Junction.As;
 

--- a/test/JoinMonster.Tests.Unit/Builders/SortKeyBuilderTests.cs
+++ b/test/JoinMonster.Tests.Unit/Builders/SortKeyBuilderTests.cs
@@ -16,7 +16,7 @@ namespace JoinMonster.Tests.Unit.Builders
 
             builder.By("id");
 
-            builder.SortKey.Should().BeEquivalentTo(new SortKey("products", "id", "id", SortDirection.Ascending));
+            builder.SortKey.Should().BeEquivalentTo(new SortKey("products", "id", "id", "id", SortDirection.Ascending));
         }
 
         [Fact]
@@ -29,9 +29,9 @@ namespace JoinMonster.Tests.Unit.Builders
 
             builder.SortKey.Should()
                 .BeEquivalentTo(
-                    new SortKey("products", "sortOrder", "sortOrder", SortDirection.Ascending)
+                    new SortKey("products", "sortOrder", "sortOrder", "sortOrder", SortDirection.Ascending)
                     {
-                        ThenBy = new SortKey("products", "id", "id", SortDirection.Descending)
+                        ThenBy = new SortKey("products", "id", "id", "id", SortDirection.Descending)
 
                     });
         }
@@ -44,7 +44,7 @@ namespace JoinMonster.Tests.Unit.Builders
 
             builder.ByDescending("id");
 
-            builder.SortKey.Should().BeEquivalentTo(new SortKey("products", "id", "id", SortDirection.Descending));
+            builder.SortKey.Should().BeEquivalentTo(new SortKey("products", "id", "id", "id", SortDirection.Descending));
         }
 
         [Fact]
@@ -55,9 +55,9 @@ namespace JoinMonster.Tests.Unit.Builders
 
             builder.ByDescending("sortOrder").ThenBy("id");
 
-            builder.SortKey.Should().BeEquivalentTo(new SortKey("products", "sortOrder", "sortOrder", SortDirection.Descending)
+            builder.SortKey.Should().BeEquivalentTo(new SortKey("products", "sortOrder", "sortOrder", "sortOrder", SortDirection.Descending)
             {
-                ThenBy = new SortKey("products", "id", "id", SortDirection.Ascending)
+                ThenBy = new SortKey("products", "id", "id", "id", SortDirection.Ascending)
             });
         }
     }

--- a/test/JoinMonster.Tests.Unit/Data/PostgreSqlDialectTests.cs
+++ b/test/JoinMonster.Tests.Unit/Data/PostgreSqlDialectTests.cs
@@ -90,7 +90,7 @@ namespace JoinMonster.Tests.Unit.Data
             {
                 Join = (join, _, __, ___) => join.On("id", "productId"),
                 OrderBy = new OrderBy("products", "id", SortDirection.Ascending),
-                SortKey = new SortKey("products", "id", "id", SortDirection.Ascending),
+                SortKey = new SortKey("products", "id", "id", "id", SortDirection.Ascending),
                 Where = (where, _, __, ___) => where.Column("id", 1, "<>")
 
             };
@@ -125,7 +125,7 @@ namespace JoinMonster.Tests.Unit.Data
                 true)
             {
                 Join = (join, _, __, ___) => join.On("id", "productId"),
-                SortKey = new SortKey("products", "id", "id", SortDirection.Descending),
+                SortKey = new SortKey("products", "id", "id", "id", SortDirection.Descending),
                 Where = (where, _, __, ___) => where.Column("id", 1, "<>")
 
             };
@@ -148,7 +148,7 @@ namespace JoinMonster.Tests.Unit.Data
                     .Contain(@"LEFT JOIN LATERAL (
   SELECT ""variants"".*
   FROM ""variants"" ""variants""
-  WHERE ""products"".""id"" = ""variants"".""productId"" AND ""variants"".""id"" <> @p0 AND (""variants"".""id"") > (@p1)
+  WHERE ""products"".""id"" = ""variants"".""productId"" AND ""variants"".""id"" <> @p0 AND (""variants"".""id"" < @p1)
   ORDER BY ""variants"".""id"" DESC
   LIMIT 3
 ) ""variants"" ON ""products"".""id"" = ""variants"".""productId""");
@@ -173,7 +173,7 @@ namespace JoinMonster.Tests.Unit.Data
             {
                 Join = (join, _, __, ____) => join.On("id", "productId"),
                 OrderBy = new OrderBy("products", "id", SortDirection.Ascending),
-                SortKey = new SortKey("products", "id", "id", SortDirection.Ascending),
+                SortKey = new SortKey("products", "id", "id", "id", SortDirection.Ascending),
                 Where = (where, _, __, ___) => where.Column("id", 1, "<>")
             };
             node.AddColumn("id", "id", "id", true);
@@ -195,7 +195,7 @@ namespace JoinMonster.Tests.Unit.Data
                     .Contain(@"LEFT JOIN LATERAL (
   SELECT ""variants"".*
   FROM ""variants"" ""variants""
-  WHERE ""products"".""id"" = ""variants"".""productId"" AND ""variants"".""id"" <> @p0 AND (""variants"".""id"") < (@p1)
+  WHERE ""products"".""id"" = ""variants"".""productId"" AND ""variants"".""id"" <> @p0 AND (""variants"".""id"" < @p1)
   ORDER BY ""variants"".""id"" DESC
   LIMIT 6
 ) ""variants"" ON ""products"".""id"" = ""variants"".""productId""");
@@ -255,7 +255,7 @@ namespace JoinMonster.Tests.Unit.Data
                 true)
             {
                 OrderBy = new OrderBy("products", "id", SortDirection.Ascending),
-                SortKey = new SortKey("products", "id", "id", SortDirection.Ascending),
+                SortKey = new SortKey("products", "id", "id", "id", SortDirection.Ascending),
                 Where = (where, _, __, ___) => where.Column("id", 1, "<>")
             };
             node.AddColumn("id", "id", "id", true);
@@ -292,7 +292,7 @@ namespace JoinMonster.Tests.Unit.Data
             var compilerContext = new SqlCompilerContext(new SqlCompiler(dialect));
             var node = new SqlTable(null, null, "variants", "variants", "variants", new Dictionary<string, object>(), true)
             {
-                SortKey = new SortKey("products", "id", "id", SortDirection.Descending),
+                SortKey = new SortKey("products", "id", "id", "id", SortDirection.Descending),
                 Where = (where, _, __, ___) => where.Column("id", 1, "<>")
             };
             node.AddColumn("id", "id", "id", true);
@@ -313,7 +313,7 @@ namespace JoinMonster.Tests.Unit.Data
                     .Contain(@"FROM (
   SELECT ""variants"".*
   FROM variants ""variants""
-  WHERE (""variants"".""id"") > (@p0) AND ""variants"".""id"" <> @p1
+  WHERE (""variants"".""id"" < @p0) AND ""variants"".""id"" <> @p1
   ORDER BY ""variants"".""id"" DESC
   LIMIT 3
 ) ""variants""");
@@ -334,9 +334,9 @@ namespace JoinMonster.Tests.Unit.Data
             var compilerContext = new SqlCompilerContext(new SqlCompiler(dialect));
             var node = new SqlTable(null, null, "variants", "variants", "variants", new Dictionary<string, object>(), true)
             {
-                SortKey = new SortKey("products", "price", "price", SortDirection.Descending)
+                SortKey = new SortKey("products", "price", "price", "price", SortDirection.Descending)
                 {
-                    ThenBy = new SortKey("products", "name", "name", SortDirection.Ascending)
+                    ThenBy = new SortKey("products", "name", "name", "name", SortDirection.Ascending)
                 },
                 Where = (where, _, __, ___) => where.Column("id", 1, "<>")
             };
@@ -358,7 +358,7 @@ namespace JoinMonster.Tests.Unit.Data
                     .Contain(@"FROM (
   SELECT ""variants"".*
   FROM variants ""variants""
-  WHERE (""variants"".""price"", ""variants"".""name"") > (@p0, @p1) AND ""variants"".""id"" <> @p2
+  WHERE (""variants"".""price"" < @p0 AND ""variants"".""name"" > @p1) AND ""variants"".""id"" <> @p2
   ORDER BY ""variants"".""price"" DESC, ""variants"".""name"" ASC
   LIMIT 3
 ) ""variants""");
@@ -381,7 +381,7 @@ namespace JoinMonster.Tests.Unit.Data
             var node = new SqlTable(null, null, "variants", "variants", "variants", new Dictionary<string, object>(), true)
             {
                 OrderBy = new OrderBy("products", "id", SortDirection.Ascending),
-                SortKey = new SortKey("products", "id", "id", SortDirection.Ascending),
+                SortKey = new SortKey("products", "id", "id", "id", SortDirection.Ascending),
                 Where = (where, _, __, ___) => where.Column("id", 1, "<>")
             };
             node.AddColumn("id", "id", "id", true);
@@ -402,7 +402,7 @@ namespace JoinMonster.Tests.Unit.Data
                     .Contain(@"FROM (
   SELECT ""variants"".*
   FROM variants ""variants""
-  WHERE (""variants"".""id"") < (@p0) AND ""variants"".""id"" <> @p1
+  WHERE (""variants"".""id"" < @p0) AND ""variants"".""id"" <> @p1
   ORDER BY ""variants"".""id"" DESC
   LIMIT 6
 ) ""variants""");

--- a/test/JoinMonster.Tests.Unit/ObjectShaperTests.cs
+++ b/test/JoinMonster.Tests.Unit/ObjectShaperTests.cs
@@ -19,7 +19,7 @@ namespace JoinMonster.Tests.Unit
             var variantsTable = node.AddTable(null, "variants", "variants", "variants", new Dictionary<string, object>(), true);
             variantsTable.AddColumn("id", "id", "id", true);
             variantsTable.AddColumn("name", "name", "name");
-            variantsTable.SortKey = new SortKey("products", "sortOrder", "sortOrder", SortDirection.Ascending);
+            variantsTable.SortKey = new SortKey("products", "sortOrder", "sortOrder", "sortOrder", SortDirection.Ascending);
             var colorsTable = variantsTable.AddTable(null, "colors", "color", "color", new Dictionary<string, object>(), true);
             colorsTable.AddColumn("id", "id", "id", true);
             colorsTable.AddColumn("color", "color", "color");


### PR DESCRIPTION
The logic for doing keyset paging didn't generate the correct where clauses when sorting in descending order. Instead of using the sort keys sort direction it only looked for the `after` argument, and if that was present it reversed the where.

Also if there where multiple sort keys they where generating a single where like `("variants"."price", "variants"."name") > (@p0, @p1)` instead of `("variants"."price" < @p0 AND "variants"."name" > @p1)` (where price is ordered descending and name ascending)