### PR TITLE
Fix sorting by JSON fields and keyset paging with multiple sort keys

### DIFF
--- a/src/JoinMonster/ArrayToConnectionConverter.cs
+++ b/src/JoinMonster/ArrayToConnectionConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using GraphQL;
 using GraphQL.Types.Relay.DataObjects;
@@ -88,7 +89,7 @@ namespace JoinMonster
                         if (dataArr.Count > System.Convert.ToInt32(last))
                         {
                             hasPreviousPage = true;
-                            dataArr.RemoveAt(0);
+                            dataArr.RemoveAt(dataArr.Count - 1);
                         }
 
                         dataArr.Reverse();
@@ -101,7 +102,21 @@ namespace JoinMonster
                         var sort = sortKey!;
                         do
                         {
-                            cursor[sort.Column] = obj[sort.Column];
+                            var value = obj[sort.Column];
+                            if (sort.Type != null)
+                            {
+                                if (sort.Type == typeof(DateTime) && value is string strVal)
+                                {
+                                    // TODO: is this needed?
+                                    value = DateTime.Parse(strVal, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
+                                }
+                                else
+                                {
+                                    value = System.Convert.ChangeType(value, sort.Type, CultureInfo.InvariantCulture);
+                                }
+                            }
+
+                            cursor[sort.As] = value;
                         } while ((sort = sort.ThenBy) != null);
 
                         return new Edge<object> {Cursor = ConnectionUtils.ObjectToCursor(cursor), Node = obj};

--- a/src/JoinMonster/Builders/SortKeyBuilder.cs
+++ b/src/JoinMonster/Builders/SortKeyBuilder.cs
@@ -25,20 +25,20 @@ namespace JoinMonster.Builders
         /// Sort the result by the <paramref name="column"/> in ascending order.
         /// </summary>
         /// <param name="column">The column name.</param>
-        /// <param name="whereColumn">The column name used for the where clause.</param>
-        public ThenSortKeyBuilder By(string column, string? whereColumn = null) => By(column, whereColumn, SortDirection.Ascending);
+        /// <param name="type">The column type.</param>
+        public ThenSortKeyBuilder By(string column, Type? type = null) => By(column, type, SortDirection.Ascending);
 
 
         /// <summary>
         /// Sort the result by the <paramref name="column"/> in descending order.
         /// </summary>
         /// <param name="column">The column name.</param>
-        /// <param name="whereColumn">The column name used for the where clause.</param>
-        public ThenSortKeyBuilder ByDescending(string column, string? whereColumn = null) => By(column, whereColumn, SortDirection.Descending);
+        /// <param name="type">The column type.</param>
+        public ThenSortKeyBuilder ByDescending(string column, Type? type = null) => By(column, type, SortDirection.Descending);
 
-        private ThenSortKeyBuilder By(string column, string? whereColumn, SortDirection direction)
+        private ThenSortKeyBuilder By(string column, Type? type, SortDirection direction)
         {
-            SortKey = new SortKey(Table, column, whereColumn, _aliasGenerator.GenerateColumnAlias(column), direction);
+            SortKey = new SortKey(Table, column, _aliasGenerator.GenerateColumnAlias(column), type, direction);
             return new ThenSortKeyBuilder(Table, SortKey, _aliasGenerator);
         }
     }
@@ -64,20 +64,20 @@ namespace JoinMonster.Builders
         /// Sort the result by the <paramref name="column"/> in ascending order.
         /// </summary>
         /// <param name="column">The column name.</param>
-        /// <param name="whereColumn">The column name used for the where clause.</param>
-        public ThenSortKeyBuilder ThenBy(string column, string? whereColumn = null) => ThenBy(column, whereColumn, SortDirection.Ascending);
+        /// <param name="type">The column type.</param>
+        public ThenSortKeyBuilder ThenBy(string column, Type? type = null) => ThenBy(column, type, SortDirection.Ascending);
 
 
         /// <summary>
         /// Sort the result by the <paramref name="column"/> in descending order.
         /// </summary>
         /// <param name="column">The column name.</param>
-        /// <param name="whereColumn">The column name used for the where clause.</param>
-        public ThenSortKeyBuilder ThenByDescending(string column, string? whereColumn = null) => ThenBy(column, whereColumn, SortDirection.Descending);
+        /// <param name="type">The column type.</param>
+        public ThenSortKeyBuilder ThenByDescending(string column, Type? type = null) => ThenBy(column, type, SortDirection.Descending);
 
-        private ThenSortKeyBuilder ThenBy(string column, string? whereColumn, SortDirection direction)
+        private ThenSortKeyBuilder ThenBy(string column, Type? type, SortDirection direction)
         {
-            SortKey.ThenBy = new SortKey(Table, column, whereColumn, _aliasGenerator.GenerateColumnAlias(column), direction);
+            SortKey.ThenBy = new SortKey(Table, column, _aliasGenerator.GenerateColumnAlias(column), type, direction);
             return new ThenSortKeyBuilder(Table, SortKey.ThenBy, _aliasGenerator);
         }
     }

--- a/src/JoinMonster/Language/AST/SortKey.cs
+++ b/src/JoinMonster/Language/AST/SortKey.cs
@@ -5,19 +5,19 @@ namespace JoinMonster.Language.AST
 {
     public class SortKey
     {
-        public SortKey(string table, string column, string? whereColumn, string @as, SortDirection direction)
+        public SortKey(string table, string column, string @as, Type? type, SortDirection direction)
         {
             Table = table ?? throw new ArgumentNullException(nameof(table));
             Column = column ?? throw new ArgumentNullException(nameof(column));
-            WhereColumn = whereColumn ?? column;
             As = @as ?? throw new ArgumentNullException(nameof(@as));
+            Type = type;
             Direction = direction;
         }
 
         public string Table { get; }
         public string Column { get; }
-        public string WhereColumn { get; }
         public string As { get; }
+        public Type? Type { get; }
         public SortDirection Direction { get; }
         public SortKey? ThenBy { get; set; }
     }

--- a/src/JoinMonster/Language/QueryToSqlConverter.cs
+++ b/src/JoinMonster/Language/QueryToSqlConverter.cs
@@ -205,8 +205,7 @@ namespace JoinMonster.Language
 
                 do
                 {
-
-                    var newChild = new SqlColumn(sqlTable, sortKey.WhereColumn, sortKey.Column, sortKey.As);
+                    var newChild = new SqlColumn(sqlTable, sortKey.Column, sortKey.Column, sortKey.As);
                     if (sqlTable.SortKey == null && sqlTable.Junction != null)
                         newChild.FromOtherTable = sqlTable.Junction.As;
 

--- a/test/JoinMonster.Tests.Unit/Builders/SortKeyBuilderTests.cs
+++ b/test/JoinMonster.Tests.Unit/Builders/SortKeyBuilderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using JoinMonster.Builders;
@@ -14,9 +15,9 @@ namespace JoinMonster.Tests.Unit.Builders
             var aliasGenerator = new DefaultAliasGenerator();
             var builder = new SortKeyBuilder("products", aliasGenerator);
 
-            builder.By("id");
+            builder.By("id", typeof(Guid));
 
-            builder.SortKey.Should().BeEquivalentTo(new SortKey("products", "id", "id", "id", SortDirection.Ascending));
+            builder.SortKey.Should().BeEquivalentTo(new SortKey("products", "id", "id", typeof(Guid), SortDirection.Ascending));
         }
 
         [Fact]
@@ -25,14 +26,13 @@ namespace JoinMonster.Tests.Unit.Builders
             var aliasGenerator = new DefaultAliasGenerator();
             var builder = new SortKeyBuilder("products", aliasGenerator);
 
-            builder.By("sortOrder").ThenByDescending("id");
+            builder.By("sortOrder", typeof(int)).ThenByDescending("id", typeof(Guid));
 
             builder.SortKey.Should()
                 .BeEquivalentTo(
-                    new SortKey("products", "sortOrder", "sortOrder", "sortOrder", SortDirection.Ascending)
+                    new SortKey("products", "sortOrder", "sortOrder", typeof(int), SortDirection.Ascending)
                     {
-                        ThenBy = new SortKey("products", "id", "id", "id", SortDirection.Descending)
-
+                        ThenBy = new SortKey("products", "id", "id", typeof(Guid), SortDirection.Descending)
                     });
         }
 
@@ -42,9 +42,9 @@ namespace JoinMonster.Tests.Unit.Builders
             var aliasGenerator = new DefaultAliasGenerator();
             var builder = new SortKeyBuilder("products", aliasGenerator);
 
-            builder.ByDescending("id");
+            builder.ByDescending("id", typeof(Guid));
 
-            builder.SortKey.Should().BeEquivalentTo(new SortKey("products", "id", "id", "id", SortDirection.Descending));
+            builder.SortKey.Should().BeEquivalentTo(new SortKey("products", "id", "id", typeof(Guid), SortDirection.Descending));
         }
 
         [Fact]
@@ -53,11 +53,11 @@ namespace JoinMonster.Tests.Unit.Builders
             var aliasGenerator = new DefaultAliasGenerator();
             var builder = new SortKeyBuilder("products", aliasGenerator);
 
-            builder.ByDescending("sortOrder").ThenBy("id");
+            builder.ByDescending("sortOrder", typeof(int)).ThenBy("id", typeof(Guid));
 
-            builder.SortKey.Should().BeEquivalentTo(new SortKey("products", "sortOrder", "sortOrder", "sortOrder", SortDirection.Descending)
+            builder.SortKey.Should().BeEquivalentTo(new SortKey("products", "sortOrder", "sortOrder", typeof(int), SortDirection.Descending)
             {
-                ThenBy = new SortKey("products", "id", "id", "id", SortDirection.Ascending)
+                ThenBy = new SortKey("products", "id", "id", typeof(Guid), SortDirection.Ascending)
             });
         }
     }

--- a/test/JoinMonster.Tests.Unit/Data/PostgreSqlDialectTests.cs
+++ b/test/JoinMonster.Tests.Unit/Data/PostgreSqlDialectTests.cs
@@ -90,7 +90,7 @@ namespace JoinMonster.Tests.Unit.Data
             {
                 Join = (join, _, __, ___) => join.On("id", "productId"),
                 OrderBy = new OrderBy("products", "id", SortDirection.Ascending),
-                SortKey = new SortKey("products", "id", "id", "id", SortDirection.Ascending),
+                SortKey = new SortKey("products", "id", "id", typeof(int), SortDirection.Ascending),
                 Where = (where, _, __, ___) => where.Column("id", 1, "<>")
 
             };
@@ -125,7 +125,7 @@ namespace JoinMonster.Tests.Unit.Data
                 true)
             {
                 Join = (join, _, __, ___) => join.On("id", "productId"),
-                SortKey = new SortKey("products", "id", "id", "id", SortDirection.Descending),
+                SortKey = new SortKey("products", "id", "id", typeof(int), SortDirection.Descending),
                 Where = (where, _, __, ___) => where.Column("id", 1, "<>")
 
             };
@@ -148,7 +148,7 @@ namespace JoinMonster.Tests.Unit.Data
                     .Contain(@"LEFT JOIN LATERAL (
   SELECT ""variants"".*
   FROM ""variants"" ""variants""
-  WHERE ""products"".""id"" = ""variants"".""productId"" AND ""variants"".""id"" <> @p0 AND (""variants"".""id"" < @p1)
+  WHERE ""products"".""id"" = ""variants"".""productId"" AND ""variants"".""id"" <> @p0 AND ""variants"".""id"" < @p1
   ORDER BY ""variants"".""id"" DESC
   LIMIT 3
 ) ""variants"" ON ""products"".""id"" = ""variants"".""productId""");
@@ -173,7 +173,7 @@ namespace JoinMonster.Tests.Unit.Data
             {
                 Join = (join, _, __, ____) => join.On("id", "productId"),
                 OrderBy = new OrderBy("products", "id", SortDirection.Ascending),
-                SortKey = new SortKey("products", "id", "id", "id", SortDirection.Ascending),
+                SortKey = new SortKey("products", "id", "id", typeof(int), SortDirection.Ascending),
                 Where = (where, _, __, ___) => where.Column("id", 1, "<>")
             };
             node.AddColumn("id", "id", "id", true);
@@ -195,7 +195,7 @@ namespace JoinMonster.Tests.Unit.Data
                     .Contain(@"LEFT JOIN LATERAL (
   SELECT ""variants"".*
   FROM ""variants"" ""variants""
-  WHERE ""products"".""id"" = ""variants"".""productId"" AND ""variants"".""id"" <> @p0 AND (""variants"".""id"" < @p1)
+  WHERE ""products"".""id"" = ""variants"".""productId"" AND ""variants"".""id"" <> @p0 AND ""variants"".""id"" < @p1
   ORDER BY ""variants"".""id"" DESC
   LIMIT 6
 ) ""variants"" ON ""products"".""id"" = ""variants"".""productId""");
@@ -255,7 +255,7 @@ namespace JoinMonster.Tests.Unit.Data
                 true)
             {
                 OrderBy = new OrderBy("products", "id", SortDirection.Ascending),
-                SortKey = new SortKey("products", "id", "id", "id", SortDirection.Ascending),
+                SortKey = new SortKey("products", "id", "id", typeof(int), SortDirection.Ascending),
                 Where = (where, _, __, ___) => where.Column("id", 1, "<>")
             };
             node.AddColumn("id", "id", "id", true);
@@ -292,7 +292,7 @@ namespace JoinMonster.Tests.Unit.Data
             var compilerContext = new SqlCompilerContext(new SqlCompiler(dialect));
             var node = new SqlTable(null, null, "variants", "variants", "variants", new Dictionary<string, object>(), true)
             {
-                SortKey = new SortKey("products", "id", "id", "id", SortDirection.Descending),
+                SortKey = new SortKey("products", "id", "id", typeof(int), SortDirection.Descending),
                 Where = (where, _, __, ___) => where.Column("id", 1, "<>")
             };
             node.AddColumn("id", "id", "id", true);
@@ -313,7 +313,7 @@ namespace JoinMonster.Tests.Unit.Data
                     .Contain(@"FROM (
   SELECT ""variants"".*
   FROM variants ""variants""
-  WHERE (""variants"".""id"" < @p0) AND ""variants"".""id"" <> @p1
+  WHERE ""variants"".""id"" < @p0 AND ""variants"".""id"" <> @p1
   ORDER BY ""variants"".""id"" DESC
   LIMIT 3
 ) ""variants""");
@@ -334,9 +334,9 @@ namespace JoinMonster.Tests.Unit.Data
             var compilerContext = new SqlCompilerContext(new SqlCompiler(dialect));
             var node = new SqlTable(null, null, "variants", "variants", "variants", new Dictionary<string, object>(), true)
             {
-                SortKey = new SortKey("products", "price", "price", "price", SortDirection.Descending)
+                SortKey = new SortKey("products", "price", "price", typeof(decimal), SortDirection.Descending)
                 {
-                    ThenBy = new SortKey("products", "name", "name", "name", SortDirection.Ascending)
+                    ThenBy = new SortKey("products", "name", "name", typeof(string), SortDirection.Ascending)
                 },
                 Where = (where, _, __, ___) => where.Column("id", 1, "<>")
             };
@@ -358,7 +358,7 @@ namespace JoinMonster.Tests.Unit.Data
                     .Contain(@"FROM (
   SELECT ""variants"".*
   FROM variants ""variants""
-  WHERE (""variants"".""price"" < @p0 AND ""variants"".""name"" > @p1) AND ""variants"".""id"" <> @p2
+  WHERE (""variants"".""price"" < @p0 OR (""variants"".""price"" = @p1 AND ""variants"".""name"" > @p2)) AND ""variants"".""id"" <> @p3
   ORDER BY ""variants"".""price"" DESC, ""variants"".""name"" ASC
   LIMIT 3
 ) ""variants""");
@@ -367,8 +367,9 @@ namespace JoinMonster.Tests.Unit.Data
                     .BeEquivalentTo(new Dictionary<string, object>
                     {
                         {"@p0", 199},
-                        {"@p1", "Jacket"},
-                        {"@p2", 1}
+                        {"@p1", 199},
+                        {"@p2", "Jacket"},
+                        {"@p3", 1}
                     });
             }
         }
@@ -381,7 +382,7 @@ namespace JoinMonster.Tests.Unit.Data
             var node = new SqlTable(null, null, "variants", "variants", "variants", new Dictionary<string, object>(), true)
             {
                 OrderBy = new OrderBy("products", "id", SortDirection.Ascending),
-                SortKey = new SortKey("products", "id", "id", "id", SortDirection.Ascending),
+                SortKey = new SortKey("products", "id", "id", typeof(int), SortDirection.Ascending),
                 Where = (where, _, __, ___) => where.Column("id", 1, "<>")
             };
             node.AddColumn("id", "id", "id", true);
@@ -402,7 +403,7 @@ namespace JoinMonster.Tests.Unit.Data
                     .Contain(@"FROM (
   SELECT ""variants"".*
   FROM variants ""variants""
-  WHERE (""variants"".""id"" < @p0) AND ""variants"".""id"" <> @p1
+  WHERE ""variants"".""id"" < @p0 AND ""variants"".""id"" <> @p1
   ORDER BY ""variants"".""id"" DESC
   LIMIT 6
 ) ""variants""");

--- a/test/JoinMonster.Tests.Unit/ObjectShaperTests.cs
+++ b/test/JoinMonster.Tests.Unit/ObjectShaperTests.cs
@@ -19,7 +19,7 @@ namespace JoinMonster.Tests.Unit
             var variantsTable = node.AddTable(null, "variants", "variants", "variants", new Dictionary<string, object>(), true);
             variantsTable.AddColumn("id", "id", "id", true);
             variantsTable.AddColumn("name", "name", "name");
-            variantsTable.SortKey = new SortKey("products", "sortOrder", "sortOrder", "sortOrder", SortDirection.Ascending);
+            variantsTable.SortKey = new SortKey("products", "sortOrder", "sortOrder", typeof(int), SortDirection.Ascending);
             var colorsTable = variantsTable.AddTable(null, "colors", "color", "color", new Dictionary<string, object>(), true);
             colorsTable.AddColumn("id", "id", "id", true);
             colorsTable.AddColumn("color", "color", "color");


### PR DESCRIPTION
When paging with multiple keys the generated where clause was incorrect, which ended up filtering out too much. 

I also added a `Type` property to the SortKey, this is needed when comparing with JSON fields since all string values is treated as text, so we need to cast the value to the correct type before it can be compared