### PR TITLE
Add support for query batching

### DIFF
--- a/src/JoinMonster/ArrayToConnectionConverter.cs
+++ b/src/JoinMonster/ArrayToConnectionConverter.cs
@@ -28,6 +28,23 @@ namespace JoinMonster
             };
         }
 
+        public object Convert(IDictionary<string, object?> data, Node sqlAst, IResolveFieldContext context)
+        {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+            if (sqlAst == null) throw new ArgumentNullException(nameof(sqlAst));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var converted = ConvertInternal(data, sqlAst, context);
+            return converted switch
+            {
+                IDictionary<string, object?> enumerable => enumerable.FirstOrDefault(),
+                Connection<object> connection => connection,
+                null => throw new JoinMonsterException("Expected result to not be null."),
+                _ => throw new JoinMonsterException(
+                    $"Expected result to be of type '{typeof(IEnumerable<IDictionary<string, object?>>)}' or '{typeof(Connection<object>)}' but was '{converted.GetType()}'")
+            };
+        }
+
         private object? ConvertInternal(object? data, Node sqlAst, IResolveFieldContext context)
         {
             foreach (var astChild in sqlAst.Children)

--- a/src/JoinMonster/Builders/Clauses/Condition.cs
+++ b/src/JoinMonster/Builders/Clauses/Condition.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace JoinMonster.Builders.Clauses
@@ -65,5 +66,17 @@ namespace JoinMonster.Builders.Clauses
         }
 
         public IEnumerable<WhereCondition> Conditions { get; }
+    }
+
+    public class InCondition : WhereCondition
+    {
+        public InCondition(string table, string column, IEnumerable values) : base(table)
+        {
+            Column = column ?? throw new ArgumentNullException(nameof(column));
+            Values = values ?? throw new ArgumentNullException(nameof(values));
+        }
+
+        public string Column { get; }
+        public IEnumerable Values { get; }
     }
 }

--- a/src/JoinMonster/Builders/SqlBatchConfigBuilder.cs
+++ b/src/JoinMonster/Builders/SqlBatchConfigBuilder.cs
@@ -1,0 +1,81 @@
+using System;
+using JoinMonster.Configs;
+
+namespace JoinMonster.Builders
+{
+    /// <summary>
+    /// A helper class for fluently creating a <see cref="SqlBatchConfig"/> object.
+    /// </summary>
+    public class SqlBatchConfigBuilder
+    {
+        private SqlBatchConfigBuilder(SqlBatchConfig sqlBatchConfig)
+        {
+            SqlBatchConfig = sqlBatchConfig;
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="SqlBatchConfigBuilder"/>.
+        /// </summary>
+        /// <param name="thisKey">The column to match on the current table.</param>
+        /// <param name="parentKey">The column to match on the other table.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="thisKey"/> or <paramref name="parentKey"/> is null.</exception>
+        /// <returns>The <see cref="SqlBatchConfigBuilder"/>.</returns>
+        public static SqlBatchConfigBuilder Create(string thisKey, string parentKey)
+        {
+            if (thisKey == null) throw new ArgumentNullException(nameof(thisKey));
+            if (parentKey == null) throw new ArgumentNullException(nameof(parentKey));
+
+            var config = new SqlBatchConfig(thisKey, parentKey);
+
+            return new SqlBatchConfigBuilder(config);
+        }
+
+        /// <summary>
+        /// The SQL batch configuration.
+        /// </summary>
+        public SqlBatchConfig SqlBatchConfig { get; }
+
+        /// <summary>
+        /// Set a method that resolves to a RAW SQL expression.
+        /// </summary>
+        /// <param name="expression">The expression resolver.</param>
+        /// <returns>The <see cref="SqlBatchConfigBuilder"/>.</returns>
+        public SqlBatchConfigBuilder ThisKey(ExpressionDelegate expression)
+        {
+            SqlBatchConfig.ThisKeyExpression = expression;
+            return this;
+        }
+
+        /// <summary>
+        /// Set a method that resolves to a RAW SQL expression.
+        /// </summary>
+        /// <param name="expression">The expression resolver.</param>
+        /// <returns>The <see cref="SqlBatchConfigBuilder"/>.</returns>
+        public SqlBatchConfigBuilder ParentKey(ExpressionDelegate expression)
+        {
+            SqlBatchConfig.ParentKeyExpression = expression;
+            return this;
+        }
+
+        /// <summary>
+        /// Set a method that resolves the WHERE condition.
+        /// </summary>
+        /// <param name="where">The WHERE condition.</param>
+        public SqlBatchConfigBuilder Where(BatchWhereDelegate where)
+        {
+            SqlBatchConfig.Where = where;
+            return this;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="join">The JOIN condition when joining from the junction table to the related table.</param>
+        /// <returns>The <see cref="SqlBatchConfigBuilder"/>.</returns>
+        public SqlBatchConfigBuilder Join(JoinDelegate join)
+        {
+            SqlBatchConfig.Join = join;
+            return this;
+        }
+    }
+}

--- a/src/JoinMonster/Builders/SqlJunctionConfigBuilder.cs
+++ b/src/JoinMonster/Builders/SqlJunctionConfigBuilder.cs
@@ -24,7 +24,6 @@ namespace JoinMonster.Builders
         /// <param name="tableName">The junction table name.</param>
         /// <param name="fromParent">The JOIN condition when joining from the parent table to the junction table.</param>
         /// <param name="toChild">The JOIN condition when joining from the junction table to the child table.</param>
-        /// <returns>The <see cref="SqlJunctionConfig"/>.</returns>
         /// <returns>The <see cref="SqlJunctionConfigBuilder"/>.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="tableName"/>, <paramref name="fromParent"/> or <paramref name="toChild"/> is <c>null</c>.</exception>
         public static SqlJunctionConfigBuilder Create(string tableName, JoinDelegate fromParent, JoinDelegate toChild)
@@ -34,6 +33,32 @@ namespace JoinMonster.Builders
             if (toChild == null) throw new ArgumentNullException(nameof(toChild));
 
             var config = new SqlJunctionConfig(tableName, fromParent, toChild);
+
+            return new SqlJunctionConfigBuilder(config);
+        }
+
+        /// <summary>
+        /// Create a new instance of the <see cref="SqlJunctionConfigBuilder"/> configured for batching the many-to-many query.
+        /// </summary>
+        /// <param name="tableName">The junction table name.</param>
+        /// <param name="uniqueKey">The unique key columns.</param>
+        /// <param name="thisKey">The column to match on the current table.</param>
+        /// <param name="parentKey">The column to match in the parent table.</param>
+        /// <param name="join">The JOIN condition when joining from the junction table to the related table.</param>
+        /// <returns>The <see cref="SqlJunctionConfigBuilder"/>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="tableName"/>, <paramref name="uniqueKey"/>, <paramref name="thisKey"/>, <paramref name="parentKey"/> or <paramref name="join"/> is <c>null</c>.</exception>
+        public static SqlJunctionConfigBuilder Create(string tableName, string[] uniqueKey, string thisKey, string parentKey, JoinDelegate join)
+        {
+            if (tableName == null) throw new ArgumentNullException(nameof(tableName));
+            if (thisKey == null) throw new ArgumentNullException(nameof(thisKey));
+            if (parentKey == null) throw new ArgumentNullException(nameof(parentKey));
+            if (join == null) throw new ArgumentNullException(nameof(join));
+
+            var sqlBatchBuilder = SqlBatchConfigBuilder
+                .Create(thisKey, parentKey)
+                .Join(join);
+
+            var config = new SqlJunctionConfig(tableName, uniqueKey, sqlBatchBuilder.SqlBatchConfig);
 
             return new SqlJunctionConfigBuilder(config);
         }

--- a/src/JoinMonster/Builders/WhereBuilder.cs
+++ b/src/JoinMonster/Builders/WhereBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using JoinMonster.Builders.Clauses;
 
@@ -79,7 +80,16 @@ namespace JoinMonster.Builders
             AddCondition(new CompareCondition(Table, column, op, value));
 
         /// <summary>
-        /// Compares a column with a value.
+        /// Compares a column with multiple values.
+        /// </summary>
+        /// <param name="column">The column.</param>
+        /// <param name="values">The values.</param>
+        /// <returns>The <see cref="WhereBuilder"/>.</returns>
+        public WhereBuilder In(string column, IEnumerable values) =>
+            AddCondition(new InCondition(Table, column, values));
+
+        /// <summary>
+        /// Adds a raw SQL condition.
         /// </summary>
         /// <param name="sql">The raw sql condition.</param>
         /// <param name="parameters">The parameters.</param>
@@ -88,7 +98,7 @@ namespace JoinMonster.Builders
             AddCondition(new RawCondition(sql, parameters?.ToDictionary()));
 
         /// <summary>
-        /// Compares a column with a value.
+        /// Adds a raw SQL condition.
         /// </summary>
         /// <param name="sql">The raw sql condition.</param>
         /// <param name="parameters">The parameters.</param>

--- a/src/JoinMonster/Configs/Delegates.cs
+++ b/src/JoinMonster/Configs/Delegates.cs
@@ -1,5 +1,7 @@
+using System.Collections;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Threading.Tasks;
 using GraphQL;
 using JoinMonster.Builders;
@@ -44,6 +46,16 @@ namespace JoinMonster.Configs
     /// <param name="sqlAstNode">The SQL AST node.</param>
     public delegate void WhereDelegate(WhereBuilder where, IReadOnlyDictionary<string, object> arguments, IResolveFieldContext context, SqlTable sqlAstNode);
 
+    /// <summary>
+    /// Generates a <c>WHERE</c> condition.
+    /// </summary>
+    /// <param name="where">The <see cref="WhereBuilder"/>.</param>
+    /// <param name="column">The column.</param>
+    /// <param name="values">The values.</param>
+    /// <param name="arguments">The arguments.</param>
+    /// <param name="context">The context.</param>
+    /// <param name="sqlAstNode">The SQL AST node.</param>
+    public delegate void BatchWhereDelegate(WhereBuilder where, string column, IEnumerable values, IReadOnlyDictionary<string, object> arguments, IResolveFieldContext context, SqlTable sqlAstNode);
 
     /// <summary>
     /// Generates a <c>JOIN</c> condition.
@@ -77,7 +89,7 @@ namespace JoinMonster.Configs
     /// </summary>
     /// <param name="sql">The SQL query to execute.</param>
     /// <param name="parameters">The SQL parameters.</param>
-    /// <returns>A <see cref="IDataReader"/> that is used to fetch the data from the database.</returns>
+    /// <returns>A <see cref="DbDataReader"/> that is used to fetch the data from the database.</returns>
     /// <remarks>JoinMonster is responsible for closing the <see cref="IDataReader"/>.</remarks>
-    public delegate Task<IDataReader> DatabaseCallDelegate(string sql, IReadOnlyDictionary<string, object> parameters);
+    public delegate Task<DbDataReader> DatabaseCallDelegate(string sql, IReadOnlyDictionary<string, object> parameters);
 }

--- a/src/JoinMonster/Configs/SqlBatchConfig.cs
+++ b/src/JoinMonster/Configs/SqlBatchConfig.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace JoinMonster.Configs
+{
+    /// <summary>
+    /// SQL batch configuration.
+    /// </summary>
+    public class SqlBatchConfig
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="SqlBatchConfig"/>.
+        /// </summary>
+        /// <param name="thisKey">The column to match on the current table.</param>
+        /// <param name="parentKey">The column to match on the other table.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="thisKey"/> or <paramref name="parentKey"/> is null.</exception>
+        public SqlBatchConfig(string thisKey, string parentKey)
+        {
+            ThisKey = thisKey ?? throw new ArgumentNullException(nameof(thisKey));
+            ParentKey = parentKey ?? throw new ArgumentNullException(nameof(parentKey));
+        }
+
+        /// <summary>
+        /// The column to match on the current table.
+        /// </summary>
+        public string ThisKey { get; }
+
+        /// <summary>
+        /// Custom SQL expression for matching the column on the current table.
+        /// </summary>
+        public ExpressionDelegate? ThisKeyExpression { get; set; }
+
+        /// <summary>
+        /// The column to match on the other table.
+        /// </summary>
+        public string ParentKey { get; }
+
+        /// <summary>
+        /// Custom SQL expression for matching the column on the other table.
+        /// </summary>
+        public ExpressionDelegate? ParentKeyExpression { get; set; }
+
+        /// <summary>
+        /// The WHERE condition.
+        /// </summary>
+        public BatchWhereDelegate? Where { get; set; }
+
+        /// <summary>
+        /// The JOIN condition when joining from the junction table to the related table.
+        /// </summary>
+        public JoinDelegate? Join { get; set; }
+    }
+}

--- a/src/JoinMonster/Configs/SqlJunctionConfig.cs
+++ b/src/JoinMonster/Configs/SqlJunctionConfig.cs
@@ -22,21 +22,45 @@ namespace JoinMonster.Configs
         }
 
         /// <summary>
+        /// Creates a new instance of <see cref="SqlJunctionConfig"/> configured for batching the many-to-many query.
+        /// </summary>
+        /// <param name="table">The junction table name.</param>
+        /// <param name="uniqueKey">The unique key columns.</param>
+        /// <param name="batchConfig">The batch configuration.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="table"/>, <paramref name="uniqueKey"/> or <paramref name="batchConfig"/> is <c>null</c>.</exception>
+        public SqlJunctionConfig(string table, string[] uniqueKey, SqlBatchConfig batchConfig)
+        {
+            Table = table ?? throw new ArgumentNullException(nameof(table));
+            UniqueKey = uniqueKey ?? throw new ArgumentNullException(nameof(uniqueKey));
+            BatchConfig = batchConfig ?? throw new ArgumentNullException(nameof(batchConfig));
+        }
+
+        /// <summary>
         /// The Junction table name.
         /// </summary>
         public string Table { get; }
 
         /// <summary>
+        /// The unique key columns.
+        /// </summary>
+        public string[]? UniqueKey { get; }
+
+        /// <summary>
+        /// The SQL batch configuration.
+        /// </summary>
+        public SqlBatchConfig? BatchConfig { get; }
+
+        /// <summary>
         /// The JOIN condition when joining from the parent table to the junction table.
         /// First argument is the parent table, second argument is the junction table.
         /// </summary>
-        public JoinDelegate FromParent { get; }
+        public JoinDelegate? FromParent { get; }
 
         /// <summary>
         /// The JOIN condition when joining from the junction table to the child table.
         /// First argument is the junction table, second argument is the child table.
         /// </summary>
-        public JoinDelegate ToChild { get; }
+        public JoinDelegate? ToChild { get; }
 
         /// <summary>
         /// The WHERE condition.

--- a/src/JoinMonster/Data/BatchPlanner.cs
+++ b/src/JoinMonster/Data/BatchPlanner.cs
@@ -1,0 +1,316 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.Types.Relay.DataObjects;
+using JoinMonster.Configs;
+using JoinMonster.Language.AST;
+using NestHydration;
+
+namespace JoinMonster.Data
+{
+    public class BatchPlanner : IBatchPlanner
+    {
+        private readonly ISqlCompiler _compiler;
+        private readonly Hydrator _hydrator;
+        private readonly ObjectShaper _objectShaper;
+        private readonly ArrayToConnectionConverter _arrayToConnectionConverter;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="BatchPlanner"/>.
+        /// </summary>
+        /// <param name="compiler">The <see cref="ISqlCompiler"/>.</param>
+        /// <param name="hydrator">The <see cref="Hydrator"/>.</param>
+        public BatchPlanner(ISqlCompiler compiler, Hydrator hydrator)
+        {
+            _compiler = compiler ?? throw new ArgumentNullException(nameof(compiler));
+            _hydrator = hydrator ?? throw new ArgumentNullException(nameof(hydrator));
+
+            _objectShaper = new ObjectShaper(new SqlAstValidator());
+            _arrayToConnectionConverter = new ArrayToConnectionConverter();
+        }
+
+        /// <inheritdoc />
+        public async Task NextBatch(SqlTable sqlAst, object data, DatabaseCallDelegate databaseCall,
+            IResolveFieldContext context, CancellationToken cancellationToken)
+        {
+            if (sqlAst == null) throw new ArgumentNullException(nameof(sqlAst));
+            if (data == null) throw new ArgumentNullException(nameof(data));
+            if (databaseCall == null) throw new ArgumentNullException(nameof(databaseCall));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            // paginated fields are wrapped in connections. strip those off for the batching
+            if (sqlAst.Paginate)
+            {
+                if (data is Connection<object> connection)
+                    data = connection.Edges.Select(x => (IDictionary<string, object?>) x.Node).ToList();
+            }
+
+            if (data is IEnumerable<IDictionary<string, object?>> entries && entries.Any() == false)
+                return;
+
+            var tasks = sqlAst.Tables.Select(child =>
+                NextBatchChild(child, data, databaseCall, context, cancellationToken));
+
+            await Task.WhenAll(tasks);
+        }
+
+        private async Task NextBatchChild(SqlTable sqlTable, object? data, DatabaseCallDelegate databaseCall,
+            IResolveFieldContext context, CancellationToken cancellationToken)
+        {
+            var fieldName = sqlTable.FieldName;
+
+            if (data is List<object> objList)
+                data = objList.Select(x => (IDictionary<string, object?>) x);
+
+            // see if any begin a new batch
+            if (sqlTable.Batch != null || sqlTable.Junction?.Batch != null)
+            {
+                string thisKey = null!;
+                string parentKey = null!;
+
+                if (sqlTable.Batch != null)
+                {
+                    // if so, we know we'll need to get the key for matching with the parent key
+                    sqlTable.AddColumn(sqlTable.Batch.ThisKey);
+
+                    thisKey = sqlTable.Batch.ThisKey.FieldName;
+                    parentKey = sqlTable.Batch.ParentKey.FieldName;
+                }
+                else if (sqlTable.Junction?.Batch != null)
+                {
+                    sqlTable.AddColumn(sqlTable.Junction.Batch.ThisKey);
+
+                    thisKey = sqlTable.Junction.Batch.ThisKey.FieldName;
+                    parentKey = sqlTable.Junction.Batch.ParentKey.FieldName;
+                }
+
+                if (data is IEnumerable<IDictionary<string, object?>> entries)
+                {
+                    // the "batch scope" is the set of values to match this key against from the previous batch
+                    var batchScope = new List<object>();
+                    var entryList = entries.ToList();
+
+                    foreach (var entry in entryList)
+                    {
+                        var value = entry[parentKey];
+                        switch (value)
+                        {
+                            case JsonElement element:
+                                batchScope.AddRange(((IEnumerable) SqlDialect.PrepareValue(element, null))
+                                    .Cast<object>());
+                                break;
+                            default:
+                                batchScope.Add(value);
+                                break;
+                        }
+
+                    }
+
+                    if (batchScope.Count == 0) return;
+
+                    // generate the SQL, with the batch scope values incorporated in a WHERE IN clause
+                    var sqlResult = _compiler.Compile(sqlTable, context, SqlDialect.CastArray(batchScope));
+                    var objectShape = _objectShaper.DefineObjectShape(sqlTable);
+
+                    // grab the data
+                    var newData = await HandleDatabaseCall(databaseCall, sqlResult, objectShape, cancellationToken);
+                    // group the rows by the key so we can match them with the previous batch
+                    var newDataGrouped = newData.GroupBy(x => x[thisKey])
+                        .ToDictionary(x => x.Key, x => x.ToList());
+
+                    // but if we paginate, we must convert to connection type first
+                    if (sqlTable.Paginate)
+                    {
+                        //TODO: implement
+                        // foreach (var group in newDataGrouped)
+                        //     newDataGrouped[group.Key] =
+                        //         (List<Dictionary<string, object?>>)
+                        //             _arrayToConnectionConverter.Convert(group.Value, sqlTable, context);
+                    }
+
+                    // if we they want many rows, give them an array
+                    if (sqlTable.GrabMany)
+                    {
+                        foreach (var entry in entryList)
+                        {
+                            var values = new List<object>();
+                            var obj = entry[parentKey];
+                            switch (obj)
+                            {
+                                case JsonElement element:
+                                    values.AddRange(((IEnumerable) SqlDialect.PrepareValue(element, null)).Cast<object>());
+                                    break;
+                                default:
+                                    values.Add(obj);
+                                    break;
+                            }
+
+                            var res = new List<Dictionary<string, object?>>();
+                            foreach (var value in values)
+                                res.AddRange(newDataGrouped[value]);
+
+                            entry[fieldName] = res;
+                        }
+                    }
+                    else
+                    {
+                        var matchedData = new List<object>();
+                        foreach (var entry in entryList)
+                        {
+                            var ob = newDataGrouped[entry[parentKey]];
+                            if (ob != null)
+                            {
+                                entry[fieldName] =
+                                    _arrayToConnectionConverter.Convert(newDataGrouped[entry[parentKey]][0], sqlTable,
+                                        context);
+
+                                matchedData.Add(entry);
+                            }
+                            else
+                            {
+                                entry[fieldName] = null;
+                            }
+                        }
+
+                        data = matchedData;
+                    }
+
+
+                    switch (data)
+                    {
+                        case IEnumerable<IDictionary<string, object?>> list:
+                        {
+                            var nextLevelData = list
+                                .Where(x => x.Count > 0)
+                                .Select(x => (List<Dictionary<string, object?>>) x[fieldName])
+                                .Where(x => x.Count > 0)
+                                .SelectMany(x => x)
+                                .Select(x => x.ToDictionary())
+                                .AsEnumerable();
+
+                            await NextBatch(sqlTable, nextLevelData, databaseCall, context, cancellationToken);
+                            return;
+                        }
+                        case List<object> objects:
+                        {
+                            var nextLevelData = objects
+                                .Where(x => x != null);
+
+                            await NextBatch(sqlTable, nextLevelData, databaseCall, context, cancellationToken);
+                            return;
+                        }
+                    }
+                }
+
+                switch (data)
+                {
+                    case IDictionary<string, object?> dict:
+                    {
+                        var batchScope = new List<object>();
+
+                        var o = dict[parentKey];
+                        switch (o)
+                        {
+                            case JsonElement element:
+                                batchScope.AddRange(((IEnumerable) SqlDialect.PrepareValue(element, null))
+                                    .Cast<object>());
+                                break;
+                            default:
+                                batchScope.Add(o);
+                                break;
+                        }
+
+                        if (batchScope.Count == 0) return;
+
+                        var sqlResult = _compiler.Compile(sqlTable, context, SqlDialect.CastArray(batchScope));
+
+                        var objectShape = _objectShaper.DefineObjectShape(sqlTable);
+                        var newData = await HandleDatabaseCall(databaseCall, sqlResult, objectShape, cancellationToken);
+
+                        var newDataGrouped = newData.GroupBy(x => x[thisKey])
+                            .ToDictionary(x => x.Key, x => x.ToList());
+
+                        if (sqlTable.Paginate)
+                        {
+                            var targets = newDataGrouped[parentKey];
+                            dict[fieldName] = _arrayToConnectionConverter.Convert(targets, sqlTable, context);
+                        }
+                        else if (sqlTable.GrabMany)
+                        {
+                            var res = new List<object>();
+                            foreach (var value in batchScope)
+                            {
+                                res.AddRange(newDataGrouped[value]);
+                            }
+
+                            dict[fieldName] = res;
+                        }
+                        else
+                        {
+                            var targets = newDataGrouped[parentKey];
+                            dict[fieldName] = targets[0];
+                        }
+
+                        await NextBatch(sqlTable, dict[fieldName], databaseCall, context, cancellationToken);
+                        break;
+                    }
+                    case IEnumerable<IDictionary<string, object?>> list:
+                    {
+                        var nextLevelData = list
+                            .Where(x => x.Count > 0)
+                            .Select(x => (List<Dictionary<string, object?>>) x[fieldName])
+                            .Where(x => x.Count > 0)
+                            .SelectMany(x => x)
+                            .Select(x => x.ToDictionary())
+                            .AsEnumerable();
+
+                        await NextBatch(sqlTable, nextLevelData, databaseCall, context, cancellationToken);
+                        break;
+                    }
+                    default:
+                    {
+                        if (data is IDictionary<string, object?> obj)
+                        {
+                            await NextBatch(sqlTable, obj[fieldName], databaseCall, context, cancellationToken);
+                        }
+
+                        break;
+                    }
+                }
+            }
+        }
+
+        // TODO: Refactor to share code with JoinMonsterExecuter
+        private async Task<List<Dictionary<string, object?>>> HandleDatabaseCall(
+            DatabaseCallDelegate databaseCall, SqlResult sqlResult, Definition objectShape,
+            CancellationToken cancellationToken)
+        {
+            using var reader = await databaseCall(sqlResult.Sql, sqlResult.Parameters);
+
+            var data = new List<Dictionary<string, object?>>();
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                var item = new Dictionary<string, object?>();
+                for (var i = 0; i < reader.FieldCount; ++i)
+                {
+                    item[reader.GetName(i)] = await reader.IsDBNullAsync(i, cancellationToken)
+                        ? null
+                        : await reader.GetFieldValueAsync<object>(i, cancellationToken);
+                }
+
+                data.Add(item);
+            }
+
+#pragma warning disable 8620
+#pragma warning disable 8619
+            return _hydrator.Nest(data, objectShape);
+#pragma warning restore 8619
+#pragma warning restore 8620
+        }
+    }
+}

--- a/src/JoinMonster/Data/IBatchPlanner.cs
+++ b/src/JoinMonster/Data/IBatchPlanner.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+using System.Threading.Tasks;
+using GraphQL;
+using JoinMonster.Configs;
+using JoinMonster.Language.AST;
+
+namespace JoinMonster.Data
+{
+    public interface IBatchPlanner
+    {
+        Task NextBatch(SqlTable sqlAst, object data, DatabaseCallDelegate databaseCall, IResolveFieldContext context,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/JoinMonster/Data/ISqlCompiler.cs
+++ b/src/JoinMonster/Data/ISqlCompiler.cs
@@ -18,9 +18,10 @@ namespace JoinMonster.Data
         /// </summary>
         /// <param name="node">The <see cref="Node"/>.</param>
         /// <param name="context">The <see cref="IResolveFieldContext"/>.</param>
+        /// <param name="batchScope">The batch scope.</param>
         /// <returns>The compiled SQL.</returns>
         /// <exception cref="ArgumentNullException">If <c>node</c> or <c>context</c> is null.</exception>
-        SqlResult Compile(Node node, IResolveFieldContext context);
+        SqlResult Compile(Node node, IResolveFieldContext context, IEnumerable? batchScope = null);
     }
 
     public class SqlCompilerContext

--- a/src/JoinMonster/Data/ISqlDialect.cs
+++ b/src/JoinMonster/Data/ISqlDialect.cs
@@ -37,7 +37,7 @@ namespace JoinMonster.Data
         /// <param name="joinCondition">The join condition if any.</param>
         void HandleJoinedOneToManyPaginated(SqlTable parent, SqlTable node,
             IReadOnlyDictionary<string, object> arguments, IResolveFieldContext context, ICollection<string> tables,
-            SqlCompilerContext compilerContext , string? joinCondition);
+            SqlCompilerContext compilerContext, string? joinCondition);
 
         /// <summary>
         /// Handles pagination at root.
@@ -50,6 +50,14 @@ namespace JoinMonster.Data
         /// <param name="compilerContext">The sql compiler context.</param>
         void HandlePaginationAtRoot(Node? parent, SqlTable node, IReadOnlyDictionary<string, object> arguments,
             IResolveFieldContext context, ICollection<string> tables, SqlCompilerContext compilerContext);
+
+        void HandleBatchedOneToManyPaginated(Node? parent, SqlTable node, IReadOnlyDictionary<string,object> arguments,
+            IResolveFieldContext context, ICollection<string> tables, IEnumerable<object> batchScope,
+            SqlCompilerContext compilerContext);
+
+        void HandleBatchedManyToManyPaginated(Node? parent, SqlTable node, IReadOnlyDictionary<string,object> arguments,
+            IResolveFieldContext context, ICollection<string> tables, IEnumerable<object> batchScope,
+            SqlCompilerContext compilerContext, string joinCondition);
 
         string CompileConditions(IEnumerable<WhereCondition> conditions, SqlCompilerContext context);
         string CompileOrderBy(OrderBy junctionOrderBy);

--- a/src/JoinMonster/Data/SQLiteDialect.cs
+++ b/src/JoinMonster/Data/SQLiteDialect.cs
@@ -29,5 +29,13 @@ namespace JoinMonster.Data
         /// <inheritdoc />
         public override void HandlePaginationAtRoot(Node? parent, SqlTable node, IReadOnlyDictionary<string, object> arguments, IResolveFieldContext context,
             ICollection<string> tables, SqlCompilerContext compilerContext) => throw new NotSupportedException();
+
+        public override void HandleBatchedOneToManyPaginated(Node? parent, SqlTable node, IReadOnlyDictionary<string, object> arguments,
+            IResolveFieldContext context, ICollection<string> tables, IEnumerable<object> batchScope, SqlCompilerContext compilerContext) =>
+            throw new NotSupportedException();
+
+        public override void HandleBatchedManyToManyPaginated(Node? parent, SqlTable node, IReadOnlyDictionary<string, object> arguments,
+            IResolveFieldContext context, ICollection<string> tables, IEnumerable<object> batchScope, SqlCompilerContext compilerContext,
+            string joinCondition) => throw new NotSupportedException();
     }
 }

--- a/src/JoinMonster/FieldConfigExtensions.cs
+++ b/src/JoinMonster/FieldConfigExtensions.cs
@@ -78,7 +78,7 @@ namespace JoinMonster
         /// <param name="tableName">The table name.</param>
         /// <param name="fromParent">The JOIN condition when joining from the parent table to the junction table.</param>
         /// <param name="toChild">The JOIN condition when joining from the junction table to the child table.</param>
-        /// <returns>The <see cref="SqlJunctionConfig"/>.</returns>
+        /// <returns>The <see cref="SqlJunctionConfigBuilder"/>.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="fieldConfig"/> is <c>null</c>.</exception>
         public static SqlJunctionConfigBuilder SqlJunction(this FieldConfig fieldConfig, string tableName, JoinDelegate fromParent, JoinDelegate toChild)
         {
@@ -86,6 +86,25 @@ namespace JoinMonster
 
             var builder = SqlJunctionConfigBuilder.Create(tableName, fromParent, toChild);
             fieldConfig.WithMetadata(nameof(SqlJunctionConfig), builder.SqlJunctionConfig);
+            fieldConfig.Resolver ??= DictionaryFieldResolver.Instance;
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Configure one to many SQL batching.
+        /// </summary>
+        /// <param name="fieldConfig">The field config.</param>
+        /// <param name="thisKey">The column in this table.</param>
+        /// <param name="parentKey">The column in the other table.</param>
+        /// <returns>The <see cref="SqlBatchConfigBuilder"/>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="fieldConfig"/> is <c>null</c>.</exception>
+        public static SqlBatchConfigBuilder SqlBatch(this FieldConfig fieldConfig, string thisKey, string parentKey)
+        {
+            if (fieldConfig == null) throw new ArgumentNullException(nameof(fieldConfig));
+
+            var builder = SqlBatchConfigBuilder.Create(thisKey, parentKey);
+            fieldConfig.WithMetadata(nameof(SqlBatchConfig), builder.SqlBatchConfig);
             fieldConfig.Resolver ??= DictionaryFieldResolver.Instance;
 
             return builder;

--- a/src/JoinMonster/FieldTypeExtensions.cs
+++ b/src/JoinMonster/FieldTypeExtensions.cs
@@ -56,7 +56,7 @@ namespace JoinMonster
         /// Set a method that resolves the WHERE condition.
         /// </summary>
         /// <param name="fieldType">The field type.</param>
-        /// <param name="where">The WHERE condition condition.</param>
+        /// <param name="where">The WHERE condition.</param>
         /// <returns>The <see cref="FieldType"/>.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="fieldType"/> or <paramref name="where"/> is <c>null</c>.</exception>
         public static FieldType SqlWhere(this FieldType fieldType, WhereDelegate where)
@@ -130,6 +130,30 @@ namespace JoinMonster
         }
 
         /// <summary>
+        /// Create a new instance of the <see cref="SqlJunctionConfigBuilder"/> configured for batching the many-to-many query.
+        /// </summary>
+        /// <param name="fieldType">The <see cref="FieldType"/>.</param>
+        /// <param name="tableName">The junction table name.</param>
+        /// <param name="uniqueKey">The unique key columns.</param>
+        /// <param name="thisKey">The column to match on the current table.</param>
+        /// <param name="parentKey">The column to match in the parent table.</param>
+        /// <param name="join">The JOIN condition when joining from the junction table to the related table.</param>
+        /// <returns>The <see cref="SqlJunctionConfigBuilder"/>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="fieldType"/>, <paramref name="tableName"/>, <paramref name="uniqueKey"/>, <paramref name="thisKey"/>, <paramref name="parentKey"/> or <paramref name="join"/> is <c>null</c>.</exception>
+        public static SqlJunctionConfigBuilder SqlJunction(this FieldType fieldType, string tableName, string[] uniqueKey, string thisKey, string parentKey, JoinDelegate join)
+        {
+            if (fieldType == null) throw new ArgumentNullException(nameof(fieldType));
+            if (tableName == null) throw new ArgumentNullException(nameof(tableName));
+            if (thisKey == null) throw new ArgumentNullException(nameof(thisKey));
+            if (parentKey == null) throw new ArgumentNullException(nameof(parentKey));
+            if (join == null) throw new ArgumentNullException(nameof(join));
+
+            var builder = SqlJunctionConfigBuilder.Create(tableName, uniqueKey, thisKey, parentKey, join);
+            fieldType.WithMetadata(nameof(SqlJunctionConfig), builder.SqlJunctionConfig);
+            return builder;
+        }
+
+        /// <summary>
         /// Get the SQL Junction config.
         /// </summary>
         /// <param name="fieldType">The field type.</param>
@@ -140,6 +164,38 @@ namespace JoinMonster
             if (fieldType == null) throw new ArgumentNullException(nameof(fieldType));
 
             return fieldType.GetMetadata<SqlJunctionConfig>(nameof(SqlJunctionConfig));
+        }
+
+        /// <summary>
+        /// Configure one to many SQL batching.
+        /// </summary>
+        /// <param name="fieldType">The field type.</param>
+        /// <param name="thisKey">The column in this table.</param>
+        /// <param name="parentKey">The column in the other table.</param>
+        /// <returns>The <see cref="SqlBatchConfigBuilder"/>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="fieldType"/> is <c>null</c>.</exception>
+        public static SqlBatchConfigBuilder SqlBatch(this FieldType fieldType, string thisKey, string parentKey)
+        {
+            if (fieldType == null) throw new ArgumentNullException(nameof(fieldType));
+
+            var builder = SqlBatchConfigBuilder.Create(thisKey, parentKey);
+            fieldType.WithMetadata(nameof(SqlBatchConfig), builder.SqlBatchConfig);
+            fieldType.Resolver ??= DictionaryFieldResolver.Instance;
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Get the SQL Batch config.
+        /// </summary>
+        /// <param name="fieldType">The field type.</param>
+        /// <returns>A <see cref="SqlBatchConfig"/> if one is set, otherwise <c>null</c>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="fieldType"/> is <c>null</c>.</exception>
+        public static SqlBatchConfig? GetSqlBatch(this FieldType fieldType)
+        {
+            if (fieldType == null) throw new ArgumentNullException(nameof(fieldType));
+
+            return fieldType.GetMetadata<SqlBatchConfig>(nameof(SqlBatchConfig));
         }
 
         /// <summary>

--- a/src/JoinMonster/Language/AST/Node.cs
+++ b/src/JoinMonster/Language/AST/Node.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using GraphQL.Language.AST;
 

--- a/src/JoinMonster/Language/AST/SqlColumn.cs
+++ b/src/JoinMonster/Language/AST/SqlColumn.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using JoinMonster.Configs;
 
 namespace JoinMonster.Language.AST
 {
+    [DebuggerDisplay("{GetType().Name} ({Name})")]
     public class SqlColumn : SqlColumnBase
     {
         public SqlColumn(Node parent, string name, string fieldName, string @as, bool isId = false)

--- a/src/JoinMonster/Language/AST/SqlJunction.cs
+++ b/src/JoinMonster/Language/AST/SqlJunction.cs
@@ -5,21 +5,34 @@ namespace JoinMonster.Language.AST
 {
     public class SqlJunction : Node
     {
-        public SqlJunction(Node parent, string table, string @as, JoinDelegate fromParent, JoinDelegate toChild) : base(parent)
+        public SqlJunction(Node parent, string table, string @as) : base(parent)
         {
             if (parent == null) throw new ArgumentNullException(nameof(parent));
             Table = table;
             As = @as;
-            FromParent = fromParent;
-            ToChild = toChild;
         }
 
         public string Table { get; }
         public string As { get; }
-        public JoinDelegate FromParent { get; }
-        public JoinDelegate ToChild { get; }
+        public JoinDelegate? FromParent { get; set; }
+        public JoinDelegate? ToChild { get; set; }
         public WhereDelegate? Where { get; set; }
         public OrderBy? OrderBy { get; set; }
         public SortKey? SortKey { get; set; }
+        public SqlBatch? Batch { get; set; }
+    }
+
+    public class SqlBatch : Node
+    {
+        public SqlBatch(SqlColumn thisKey, SqlColumn parentKey)
+        {
+            ThisKey = thisKey;
+            ParentKey = parentKey;
+        }
+
+        public SqlColumn ThisKey { get; }
+        public SqlColumn ParentKey { get; }
+        public JoinDelegate? Join { get; set; }
+        public BatchWhereDelegate? Where { get; set; }
     }
 }

--- a/src/JoinMonster/Language/AST/SqlTable.cs
+++ b/src/JoinMonster/Language/AST/SqlTable.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using GraphQL.Execution;
 using GraphQL.Language.AST;
 using GraphQL.Types;
 using JoinMonster.Configs;
 
 namespace JoinMonster.Language.AST
 {
+    [DebuggerDisplay("{GetType().Name} ({Name})")]
     public class SqlTable : Node
     {
         public SqlTable(Node? parent, SqlTableConfig? config, string name, string fieldName, string @as,
@@ -31,6 +34,7 @@ namespace JoinMonster.Language.AST
         public ICollection<SqlColumnBase> Columns { get; }
         public ICollection<SqlTable> Tables { get; }
         public SqlJunction? Junction { get; set; }
+        public SqlBatch? Batch { get; set; }
         public WhereDelegate? Where { get; set; }
         public JoinDelegate? Join { get; set; }
         public OrderBy? OrderBy { get; set; }
@@ -40,6 +44,14 @@ namespace JoinMonster.Language.AST
         public SqlColumn AddColumn(string name, string fieldName, string @as, bool isId = false)
         {
             var column = new SqlColumn(this, name, fieldName, @as, isId);
+            Columns.Add(column);
+            return column;
+        }
+
+        public SqlColumn AddColumn(SqlColumn column)
+        {
+            if (column.Parent != this) throw new InvalidOperationError("Cannot change column parent");
+
             Columns.Add(column);
             return column;
         }

--- a/src/JoinMonster/ObjectShaper.cs
+++ b/src/JoinMonster/ObjectShaper.cs
@@ -53,14 +53,24 @@ namespace JoinMonster
                         });
                         break;
                     case SqlTable sqlTable:
-                        var childProperties = DefineObjectShape(node, prefix, sqlTable);
-                        IProperty property;
-                        if (sqlTable.GrabMany)
-                            property = new PropertyArray(sqlTable.FieldName, childProperties);
-                        else
-                            property = new PropertyObject(sqlTable.FieldName, childProperties);
+                        if (sqlTable.Batch == null)
+                        {
+                            var childProperties = DefineObjectShape(node, prefix, sqlTable);
+                            IProperty property;
+                            if (sqlTable.GrabMany)
+                                property = new PropertyArray(sqlTable.FieldName, childProperties);
+                            else
+                                property = new PropertyObject(sqlTable.FieldName, childProperties);
 
-                        properties.Add(property);
+                            properties.Add(property);
+                        }
+                        else
+                        {
+                            IProperty property = new Property(sqlTable.Batch.ParentKey.FieldName, $"{prefix}{sqlTable.Batch.ParentKey.As}");
+
+                            properties.Add(property);
+                        }
+
                         break;
                     case SqlJunction _:
                     case SqlNoop _:

--- a/test/JoinMonster.Tests.Unit/Builders/SqlBatchConfigBuilderTests.cs
+++ b/test/JoinMonster.Tests.Unit/Builders/SqlBatchConfigBuilderTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using GraphQL;
+using JoinMonster.Builders;
+using JoinMonster.Configs;
+using JoinMonster.Language.AST;
+using Xunit;
+
+namespace JoinMonster.Tests.Unit.Builders
+{
+    public class SqlBatchConfigBuilderTests
+    {
+        [Fact]
+        public void Create_WhenThisKeyIsNull_ThrowsException()
+        {
+            Action action = () => SqlBatchConfigBuilder.Create(null, null);
+
+            action.Should()
+                .Throw<ArgumentNullException>()
+                .Which.ParamName.Should()
+                .Be("thisKey");
+        }
+
+        [Fact]
+        public void Create_WhenParentKeyIsNull_ThrowsException()
+        {
+            Action action = () => SqlBatchConfigBuilder.Create("friend_id", null);
+
+            action.Should()
+                .Throw<ArgumentNullException>()
+                .Which.ParamName.Should()
+                .Be("parentKey");
+        }
+
+        [Fact]
+        public void Create_WithThisKey_SetsThisKey()
+        {
+            var thisKey = "friend_id";
+            var builder = SqlBatchConfigBuilder.Create(thisKey, "id");
+
+            builder.SqlBatchConfig.ThisKey.Should().Be(thisKey);
+        }
+
+        [Fact]
+        public void Create_WithParentKey_SetsParentKey()
+        {
+            var parentKey = "id";
+            var builder = SqlBatchConfigBuilder.Create("friend_id", parentKey);
+
+            builder.SqlBatchConfig.ParentKey.Should().Be(parentKey);
+        }
+    }
+}

--- a/test/JoinMonster.Tests.Unit/Builders/SqlJunctionConfigBuilderTests.cs
+++ b/test/JoinMonster.Tests.Unit/Builders/SqlJunctionConfigBuilderTests.cs
@@ -96,5 +96,21 @@ namespace JoinMonster.Tests.Unit.Builders
 
             builder.SqlJunctionConfig.Where.Should().Be((WhereDelegate) Where);
         }
+
+        [Fact]
+        public void Create_WithBatchConfiguration_SetsBatchConfig()
+        {
+            void Join(JoinBuilder join, IReadOnlyDictionary<string, object> _, IResolveFieldContext __, SqlTable ___)
+            {
+            }
+
+            var builder = SqlJunctionConfigBuilder.Create("friends", new[] {"characterId", "friendId"}, "friendId", "id", Join);
+
+            builder.SqlJunctionConfig.BatchConfig.Should()
+                .BeEquivalentTo(new SqlBatchConfig("friendId", "id")
+                {
+                    Join = Join
+                });
+        }
     }
 }

--- a/test/JoinMonster.Tests.Unit/JoinMonsterExecuterTests.cs
+++ b/test/JoinMonster.Tests.Unit/JoinMonsterExecuterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using GraphQL;
@@ -13,7 +14,7 @@ namespace JoinMonster.Tests.Unit
         [Fact]
         public void Ctor_WhenConverterIsNull_ThrowsException()
         {
-            Action action = () => new JoinMonsterExecuter(null, null, null);
+            Action action = () => new JoinMonsterExecuter(null, null, null, null);
 
             action.Should()
                 .Throw<ArgumentNullException>()
@@ -24,7 +25,7 @@ namespace JoinMonster.Tests.Unit
         [Fact]
         public void Ctor_WhenCompilerIsNull_ThrowsException()
         {
-            Action action = () => new JoinMonsterExecuter(new QueryToSqlConverterStub(), null, null);
+            Action action = () => new JoinMonsterExecuter(new QueryToSqlConverterStub(), null, null, null);
 
             action.Should()
                 .Throw<ArgumentNullException>()
@@ -33,9 +34,20 @@ namespace JoinMonster.Tests.Unit
         }
 
         [Fact]
+        public void Ctor_WhenBatchPlannerIsNull_ThrowsException()
+        {
+            Action action = () => new JoinMonsterExecuter(new QueryToSqlConverterStub(), new SqlCompilerStub(), null, null);
+
+            action.Should()
+                .Throw<ArgumentNullException>()
+                .Which.ParamName.Should()
+                .Be("batchPlanner");
+        }
+
+        [Fact]
         public void Ctor_WhenHydratorIsNull_ThrowsException()
         {
-            Action action = () => new JoinMonsterExecuter(new QueryToSqlConverterStub(), new SqlCompilerStub(), null);
+            Action action = () => new JoinMonsterExecuter(new QueryToSqlConverterStub(), new SqlCompilerStub(), new BatchPlannerStub(), null);
 
             action.Should()
                 .Throw<ArgumentNullException>()
@@ -46,9 +58,9 @@ namespace JoinMonster.Tests.Unit
         [Fact]
         public void Execute_WhenContextIsNull_ThrowsException()
         {
-            var sut = new JoinMonsterExecuter(new QueryToSqlConverterStub(), new SqlCompilerStub(), new Hydrator());
+            var sut = new JoinMonsterExecuter(new QueryToSqlConverterStub(), new SqlCompilerStub(), new BatchPlannerStub(), new Hydrator());
 
-            Func<Task> action = () => sut.ExecuteAsync(null, null);
+            Func<Task> action = () => sut.ExecuteAsync(null, null, CancellationToken.None);
 
             action.Should()
                 .Throw<ArgumentNullException>()
@@ -59,9 +71,9 @@ namespace JoinMonster.Tests.Unit
         [Fact]
         public void Execute_WhenDatabaseCallIsNull_ThrowsException()
         {
-            var sut = new JoinMonsterExecuter(new QueryToSqlConverterStub(), new SqlCompilerStub(), new Hydrator());
+            var sut = new JoinMonsterExecuter(new QueryToSqlConverterStub(), new SqlCompilerStub(), new BatchPlannerStub(), new Hydrator());
 
-            Func<Task> action = () => sut.ExecuteAsync(new ResolveFieldContext(), null);
+            Func<Task> action = () => sut.ExecuteAsync(new ResolveFieldContext(), null, CancellationToken.None);
 
             action.Should()
                 .Throw<ArgumentNullException>()

--- a/test/JoinMonster.Tests.Unit/Stubs/BatchPlannerStub.cs
+++ b/test/JoinMonster.Tests.Unit/Stubs/BatchPlannerStub.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+using GraphQL;
+using JoinMonster.Configs;
+using JoinMonster.Data;
+using JoinMonster.Language.AST;
+
+namespace JoinMonster.Tests.Unit.Stubs
+{
+    public class BatchPlannerStub : IBatchPlanner
+    {
+        public Task NextBatch(SqlTable sqlAst, object data, DatabaseCallDelegate databaseCall, IResolveFieldContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/JoinMonster.Tests.Unit/Stubs/SqlCompilerStub.cs
+++ b/test/JoinMonster.Tests.Unit/Stubs/SqlCompilerStub.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using GraphQL;
 using JoinMonster.Builders.Clauses;
@@ -15,14 +16,9 @@ namespace JoinMonster.Tests.Unit.Stubs
             _sql = sql;
         }
 
-        public SqlResult Compile(Node node, IResolveFieldContext context)
+        public SqlResult Compile(Node node, IResolveFieldContext context, IEnumerable? batchScope = null)
         {
             return new SqlResult(_sql, new Dictionary<string, object>());
-        }
-
-        public string CompileConditions(IEnumerable<WhereCondition> conditions, SqlCompilerContext context)
-        {
-            throw new System.NotImplementedException();
         }
     }
 }

--- a/test/JoinMonster.Tests.Unit/Stubs/SqlDialectStub.cs
+++ b/test/JoinMonster.Tests.Unit/Stubs/SqlDialectStub.cs
@@ -10,11 +10,16 @@ namespace JoinMonster.Tests.Unit.Stubs
     {
         private readonly string _joinedOneToManyPaginatedSql;
         private readonly string _paginatedAtRootSql;
+        private readonly string _batchedOneToManyPaginatedSql;
+        private readonly string _batchedManyToManyPaginatedSql;
 
-        public SqlDialectStub(string joinedOneToManyPaginatedSql = null, string paginatedAtRootSql = null)
+        public SqlDialectStub(string joinedOneToManyPaginatedSql = null, string paginatedAtRootSql = null,
+            string batchedOneToManyPaginatedSql = null, string batchedManyToManyPaginatedSql = null)
         {
             _joinedOneToManyPaginatedSql = joinedOneToManyPaginatedSql;
             _paginatedAtRootSql = paginatedAtRootSql;
+            _batchedOneToManyPaginatedSql = batchedOneToManyPaginatedSql;
+            _batchedManyToManyPaginatedSql = batchedManyToManyPaginatedSql;
         }
 
         public override string CompositeKey(string parentTable, IEnumerable<string> keys)
@@ -35,6 +40,19 @@ namespace JoinMonster.Tests.Unit.Stubs
             SqlCompilerContext compilerContext)
         {
             tables.Add(_paginatedAtRootSql);
+        }
+
+        public override void HandleBatchedOneToManyPaginated(Node? parent, SqlTable node, IReadOnlyDictionary<string, object> arguments,
+            IResolveFieldContext resolveFieldContext, ICollection<string> tables, IEnumerable<object> batchScope, SqlCompilerContext compilerContext)
+        {
+            tables.Add(_batchedOneToManyPaginatedSql);
+        }
+
+        public override void HandleBatchedManyToManyPaginated(Node? parent, SqlTable node, IReadOnlyDictionary<string, object> arguments,
+            IResolveFieldContext context, ICollection<string> tables, IEnumerable<object> enumerable, SqlCompilerContext compilerContext,
+            string joinCondition)
+        {
+            tables.Add(_batchedManyToManyPaginatedSql);
         }
     }
 }


### PR DESCRIPTION
This is an alternative to joins, since too many joins can cause bad performance.

Batching creates multiple SQL queries while still avoiding N+1 queries. Instead of joining the query will return the keys, then the BatchPlanner will generate a WHERE IN query with all the keys from the previous query.

There's still some stuff missing like paging and ordering 🙈 , but it's not something we need right now,