### PR TITLE
Add check if result is null before batching

### DIFF
--- a/src/JoinMonster/ArrayToConnectionConverter.cs
+++ b/src/JoinMonster/ArrayToConnectionConverter.cs
@@ -10,7 +10,7 @@ namespace JoinMonster
 {
     internal class ArrayToConnectionConverter
     {
-        public object Convert(IEnumerable<IDictionary<string, object?>> data, Node sqlAst, IResolveFieldContext context)
+        public object? Convert(IEnumerable<IDictionary<string, object?>> data, Node sqlAst, IResolveFieldContext context)
         {
             if (data == null) throw new ArgumentNullException(nameof(data));
             if (sqlAst == null) throw new ArgumentNullException(nameof(sqlAst));

--- a/src/JoinMonster/JoinMonsterExecuter.cs
+++ b/src/JoinMonster/JoinMonsterExecuter.cs
@@ -50,7 +50,8 @@ namespace JoinMonster
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The correctly nested data from the database.</returns>
         /// <exception cref="ArgumentNullException">If <c>context</c> or <c>databaseCall</c> is null.</exception>
-        public async Task<object?> ExecuteAsync(IResolveFieldContext context, DatabaseCallDelegate databaseCall, CancellationToken cancellationToken)
+        public async Task<object?> ExecuteAsync(IResolveFieldContext context, DatabaseCallDelegate databaseCall,
+            CancellationToken cancellationToken)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
             if (databaseCall == null) throw new ArgumentNullException(nameof(databaseCall));
@@ -81,6 +82,8 @@ namespace JoinMonster
             var nested = _hydrator.Nest(data, objectShape);
             var result = _arrayToConnectionConverter.Convert(nested, sqlAst, context);
 #pragma warning restore 8620
+
+            if (result == null) return null;
 
             await _batchPlanner.NextBatch(sqlAst, result, databaseCall, context, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
`ArrayToConnectionConverter` can return null if the source is doesn't contain any data, this resulted in the `BatchPlanner` throwing an `ArgumentNullException` since it expect's `data` not to be null.