### PR TITLE
Fix batching when column data is in different formats

### DIFF
--- a/src/JoinMonster/JoinMonsterExecuter.cs
+++ b/src/JoinMonster/JoinMonsterExecuter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using GraphQL;
@@ -71,6 +72,9 @@ namespace JoinMonster
                         var value = await reader.IsDBNullAsync(i, cancellationToken)
                             ? null
                             : await reader.GetFieldValueAsync<object>(i, cancellationToken);
+
+                        if (value is JsonElement {ValueKind: JsonValueKind.Null or JsonValueKind.Undefined})
+                            value = null;
 
                         item[reader.GetName(i)] = value;
                     }


### PR DESCRIPTION
Fixes an issue with batching and fragments when a field uses the same db column but the data returned is different, e.g. a JSON field returning a `string` for one fragment and an `array` for another