### PR TITLE
Ensure table for field with fragments only gets queried once

### DIFF
--- a/src/JoinMonster/Language/AST/SqlNoop.cs
+++ b/src/JoinMonster/Language/AST/SqlNoop.cs
@@ -1,4 +1,7 @@
 namespace JoinMonster.Language.AST
 {
-    public class SqlNoop : Node {}
+    public class SqlNoop : Node
+    {
+        public static readonly SqlNoop Instance = new SqlNoop();
+    }
 }


### PR DESCRIPTION
This fixes an issue when the query has multiple fragments on a field that uses batching.

This fixes the issue where each fragment on the same field would be generate a new SQL query and the BatchPlanner would then overwrite the values that were previously returned for the fragments that were queried before with the new values, meaning that only the last fragment would have results.

With this fix we add the selections to the same SQL table which then only generates 1 SQL query fetching all the fields needed for each fragment