### PR TITLE
Fix multiple fragments selecting same fields not being merged correctly

### DIFF
--- a/src/JoinMonster/Language/QueryToSqlConverter.cs
+++ b/src/JoinMonster/Language/QueryToSqlConverter.cs
@@ -97,9 +97,10 @@ namespace JoinMonster.Language
             var fieldName = fieldAst.Alias?.Name.StringValue ?? field.Name;
             var tableName = config.Table(arguments, context);
 
-            if (parent is SqlTable parentTable && parentTable.Name == tableName)
+            if (parent is SqlTable parentTable)
             {
-                var existingTable = parentTable.Tables.FirstOrDefault(x => x.FieldName == fieldName);
+                var existingTable = parentTable.Tables.FirstOrDefault(x => x.FieldName == fieldName && x.Name == tableName);
+
                 // we already have a table for the field, this can happend when there's multiple fragments
                 if (existingTable is not null && fieldAst.SelectionSet is not null)
                 {


### PR DESCRIPTION
Fixes an issue where having multiple fragments selecting the same fields which generates join statements would generate a join for each fragment and thous could end up with `null` values in the responses

```gql
{
  allTextpage {
    items {
      elements {
        ... on Hero {
          desktopImage { # a join to the media table
            ... on Image {
              url
              name
              width
            }
          }
          mobileImage { # a join to the media table
            ... on Image {
              url
              name
              width
            }
          }
        }
        ... on Banner {
          desktopImage { # a join to the media table
            ... on Image {
              name
              url
            }
          }
          mobileImage { # a join to the media table
            ... on Image {
              name
              width
            }
          }
        }
      }
    }
  }
}
```

With the above query we don't select `desktopImage.width` and `mobileImage.url` for `Banner`, which results in `desktopImage.witdh` and `mobileImage.url` would be missing for `Hero`.

This is because of how the SQL would generate multiple joins for the same tables

```sql
SELECT
  "d"."id" AS "b",
  "e"."id" AS "e__b",
  "e"."url" AS "e__g",
  "e"."name" AS "e__h",
  "e"."width" AS "e__i",
  "j"."id" AS "j__b",
  "j"."url" AS "j__g",
  "j"."name" AS "j__h",
  "j"."width" AS "j__i",
  "k"."id" AS "k__b",
  "k"."name" AS "k__h",
  "k"."url" AS "k__i",
  "l"."id" AS "l__b",
  "l"."name" AS "l__h",
  "l"."width" AS "l__i"
FROM "elements" AS "d"
LEFT JOIN "media" AS "e" ON "desktopImage" = "e"."id"
LEFT JOIN "media" AS "j" ON "mobileImage" = "j"."id"
LEFT JOIN "media" AS "k" ON "desktopImage" = "k"."id"
LEFT JOIN "media" AS "l" ON "mobileImage" = "l"."id"
WHERE "d"."id" = ANY('{"7a60d7c1-eb2c-4e3b-9ff9-2d175866d8fa", "5a1e6cae-03fb-4b94-8342-8ced256d4cbf"}')
```

And then since the field names are the same, then when mapping it would use the values from the last join which in this case would be null.

With this fix the tables gets merged and only 1 join is generated per field which selects all the columns needed for both fragments

```sql
SELECT
  "d"."id" AS "b",
  "e"."id" AS "e__b",
  "e"."url" AS "e__g",
  "e"."name" AS "e__h",
  "e"."width" AS "e__i",
  "j"."id" AS "j__b",
  "j"."url" AS "j__g",
  "j"."name" AS "j__h",
  "j"."width" AS "j__i"
FROM "elements" AS "d"
LEFT JOIN "media" AS "e" ON "desktopImage" = "e"."id"
LEFT JOIN "media" AS "j" ON "mobileImage" = "j"."id"
WHERE "d"."id" = ANY('{"0b67c11e-9ee7-4ad6-a6ca-a6c14cbf8e23", "62b98cda-5278-441f-8ca2-11d97c20b644"}')
```