### PR TITLE
Batching fixes

### DIFF
--- a/src/JoinMonster/Data/BatchPlanner.cs
+++ b/src/JoinMonster/Data/BatchPlanner.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using GraphQL;
+using GraphQL.Types;
 using GraphQL.Types.Relay.DataObjects;
 using JoinMonster.Configs;
 using JoinMonster.Language.AST;
@@ -83,6 +84,10 @@ namespace JoinMonster.Data
             {
                 string thisKeyAlias = null!;
                 string parentKey = null!;
+                Func<object, bool> isTypeOf = _ => true;
+
+                if (sqlTable.ParentGraphType is IObjectGraphType { IsTypeOf: var typeOf } && typeOf is not null)
+                    isTypeOf = typeOf;
 
                 if (sqlTable.Batch != null)
                 {
@@ -108,6 +113,7 @@ namespace JoinMonster.Data
 
                     foreach (var entry in entryList)
                     {
+                        if (isTypeOf(entry) is false) continue;
                         var values = PrepareValues(entry, parentKey);
                         foreach (var value in values)
                             batchScope.Add(value);
@@ -139,6 +145,7 @@ namespace JoinMonster.Data
                     {
                         foreach (var entry in entryList)
                         {
+                            if (isTypeOf(entry) is false) continue;
                             var values = PrepareValues(entry, parentKey);
 
                             var res = new List<IDictionary<string, object?>>();

--- a/src/JoinMonster/Language/AST/SqlTable.cs
+++ b/src/JoinMonster/Language/AST/SqlTable.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using GraphQL.Execution;
+using GraphQL.Types;
+using GraphQLParser.AST;
 using JoinMonster.Configs;
 
 namespace JoinMonster.Language.AST
@@ -38,6 +40,7 @@ namespace JoinMonster.Language.AST
         public OrderBy? OrderBy { get; set; }
         public SortKey? SortKey { get; set; }
         public ColumnExpressionDelegate? ColumnExpression { get; set; }
+        internal IGraphType? ParentGraphType { get; set; }
 
         public SqlColumn AddColumn(string name, string fieldName, string @as, bool isId = false)
         {

--- a/src/JoinMonster/Language/QueryToSqlConverter.cs
+++ b/src/JoinMonster/Language/QueryToSqlConverter.cs
@@ -72,7 +72,7 @@ namespace JoinMonster.Language
                         //TODO: Validate that either join, batch or junction is set on the field
                     }
 
-                    return HandleTable(sqlTable, fieldAst, field, complexGraphType, sqlTableConfig, depth, context);
+                    return HandleTable(sqlTable, fieldAst, field, complexGraphType, parentType, sqlTableConfig, depth, context);
                 }
 
                 if (sqlColumnConfig == null)
@@ -90,7 +90,7 @@ namespace JoinMonster.Language
         }
 
         private Node HandleTable(Node? parent, GraphQLField fieldAst, FieldType field, IComplexGraphType graphType,
-            SqlTableConfig config, int depth, IResolveFieldContext context)
+            IGraphType parentGraphType, SqlTableConfig config, int depth, IResolveFieldContext context)
         {
             var arguments = HandleArguments(field, fieldAst, context);
 
@@ -130,6 +130,9 @@ namespace JoinMonster.Language
             }
 
             var sqlTable = new SqlTable(parent, config, tableName, fieldName, tableAs, arguments, grabMany)
+                {
+                    ParentGraphType = parentGraphType,
+                }
                 .WithLocation(fieldAst.Location);
 
             if (config.UniqueKey.Length == 1)


### PR DESCRIPTION
Fixes
- over fetching when batching when fragments is used
- batching when the result is a single item

For over fetching, with the following schema:

```gql
interface Content {
  name: String
}

type FeaturedProducts implements Content {
  name: String
  products: [Content] @sqlBatch
}

type DiscountedProducts implements Content {
  name: String
  products: [Content] @sqlBatch
}

query {
  allContent: [Content]
}
```

and a query like

```gql
{
  allContent {
    name
    ... on FeaturedProducts {
      products {
        name
      }
    }
  }
}
```

This would result in batch fetching the `Content` from `products` field for both `FeaturedProducts` and `DiscountedProducts` with the `products` on `DiscountedProducts` not being used since it's not requested. This could also result in an SQL error if there was another type where `products` is of another type, e.g. if one field had a collection of `UUID` and the other type stored a `text`, then the values in the SQL query would be a combination of `UUID` and `text` which would make the database return an error.

With this fix we call `IObjectGraphType.IsTypeOf` (which will be `FeaturedProducts` in this case) for each item from the previous call (in this case it's everything returned from `allContent`) to check if the value should for the field on that item should be used when batching.

The other fix is when for the a field that's batched returns a single item like

```gql
type FeaturedProducts implements Content {
  name: String
  product: Content @sqlBatch
}
```

without the fix, this would'nt work and the query would either fail or the value value would just be `null`