### PR TITLE
Fix batching when using fragments and resolving batching for a single item

### DIFF
--- a/src/JoinMonster/Data/BatchPlanner.cs
+++ b/src/JoinMonster/Data/BatchPlanner.cs
@@ -63,7 +63,7 @@ namespace JoinMonster.Data
 
             foreach (var table in sqlAst.Tables)
             {
-                await NextBatchChild(table, data, databaseCall, context, cancellationToken);
+                await NextBatchChild(table, data, databaseCall, context, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -109,11 +109,10 @@ namespace JoinMonster.Data
                 {
                     // the "batch scope" is the set of values to match this key against from the previous batch
                     var batchScope = new HashSet<object>();
-                    var entryList = entries.ToList();
+                    var entryList = entries.Where(isTypeOf).OfType<IDictionary<string, object?>>().ToList();
 
                     foreach (var entry in entryList)
                     {
-                        if (isTypeOf(entry) is false) continue;
                         var values = PrepareValues(entry, parentKey);
                         foreach (var value in values)
                             batchScope.Add(value);
@@ -145,8 +144,6 @@ namespace JoinMonster.Data
                     {
                         foreach (var entry in entryList)
                         {
-                            if (isTypeOf(entry) is false) continue;
-
                             var values = PrepareValues(entry, parentKey);
 
                             var res = new List<IDictionary<string, object?>>();

--- a/src/JoinMonster/Language/QueryToSqlConverter.cs
+++ b/src/JoinMonster/Language/QueryToSqlConverter.cs
@@ -96,22 +96,6 @@ namespace JoinMonster.Language
 
             var fieldName = fieldAst.Alias?.Name.StringValue ?? field.Name;
             var tableName = config.Table(arguments, context);
-
-            if (parent is SqlTable parentTable)
-            {
-                var existingTable = parentTable.Tables.FirstOrDefault(x => x.FieldName == fieldName && x.Name == tableName);
-
-                // we already have a table for the field, this can happend when there's multiple fragments
-                if (existingTable is not null && fieldAst.SelectionSet is not null)
-                {
-                    // lets add the fragment selections to the existing table
-                    HandleSelections(existingTable, graphType, fieldAst.SelectionSet.Selections, depth, context);
-
-                    // return SqlNoop to avoid the table being added multiple times to the selection
-                    return SqlNoop.Instance;
-                }
-            }
-
             var tableAs = _aliasGenerator.GenerateTableAlias(fieldName);
 
             var grabMany = field.ResolvedType.IsListType();


### PR DESCRIPTION
Removed table merging when there's multiple fragments that selects from the same table, this is done because with the fix in https://github.com/umbraco/join-monster-dotnet/pull/31 we would now only do batching for the first fragment.

Fixes an issue with batching on single items which is also related to https://github.com/umbraco/join-monster-dotnet/pull/31