### PR TITLE
Check if key is not null/undefined/object

### DIFF
--- a/src/JoinMonster/Data/BatchPlanner.cs
+++ b/src/JoinMonster/Data/BatchPlanner.cs
@@ -183,7 +183,7 @@ namespace JoinMonster.Data
                         foreach (var entry in entryList)
                         {
                             if (entry.TryGetValue(parentKey, out var key) is false) continue;
-                            if (key is null) continue;
+                            if (key is null || key is JsonElement { ValueKind: JsonValueKind.Null or JsonValueKind.Undefined or JsonValueKind.Object }) continue;
                             var convertedKey = SqlDialect.PrepareValue(key, null);
 
                             if (newDataGrouped.TryGetValue(convertedKey, out var list) && list.Count > 0)


### PR DESCRIPTION
Json values `Null/Undefined/Object` cannot be used as a key so we need to skip the key if it's either of those