### PR TITLE
Fix field alias with argument handling

### DIFF
--- a/src/JoinMonster/FieldAliasExtensions.cs
+++ b/src/JoinMonster/FieldAliasExtensions.cs
@@ -1,0 +1,22 @@
+using GraphQL;
+using GraphQLParser.AST;
+
+namespace JoinMonster
+{
+    public static class FieldAliasExtensions
+    {
+        public static string FieldAlias(this IResolveFieldContext context)
+        {
+            return FieldAlias(context.FieldAst, context.FieldAst.Name?.StringValue ?? context.FieldDefinition.Name);
+        }
+
+        public static string FieldAlias(this GraphQLField field, string fallbackName)
+        {
+            var fieldName = field.Name?.StringValue ?? fallbackName;
+            if (fieldName.StartsWith("__")) return fieldName;
+
+            var fieldAlias = (field.Alias?.Name ?? field.Name)?.StringValue ?? fallbackName;
+            return fieldAlias == fieldName ? fieldName : $"{fieldAlias}#{fieldName}";
+        }
+    }
+}

--- a/src/JoinMonster/Resolvers/DictionaryFieldResolver.cs
+++ b/src/JoinMonster/Resolvers/DictionaryFieldResolver.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Resolvers;
+using JoinMonster.Language;
 
 namespace JoinMonster.Resolvers
 {
@@ -25,7 +26,7 @@ namespace JoinMonster.Resolvers
         public ValueTask<object?> ResolveAsync(IResolveFieldContext context)
         {
             if (context.Source is IDictionary<string, object> dict
-                && dict.TryGetValue(context.FieldDefinition.Name, out var value))
+                && dict.TryGetValue(context.FieldAlias(), out var value))
             {
                 return new ValueTask<object?>(value);
             }

--- a/test/JoinMonster.Tests.Unit/Language/QueryToSqlConverterTests.cs
+++ b/test/JoinMonster.Tests.Unit/Language/QueryToSqlConverterTests.cs
@@ -122,7 +122,7 @@ namespace JoinMonster.Tests.Unit.Language
             node.Should()
                 .BeOfType<SqlTable>()
                 .Which.Columns.Should()
-                .ContainEquivalentOf(new SqlColumn(node, "name", "name", "name"),
+                .ContainEquivalentOf(new SqlColumn(node, "name", "productName#name", "productName#name"),
                     config => config.Excluding(x => x.Location));
         }
 

--- a/test/JoinMonster.Tests.Unit/Resolvers/DictionaryFieldResolverTests.cs
+++ b/test/JoinMonster.Tests.Unit/Resolvers/DictionaryFieldResolverTests.cs
@@ -38,7 +38,7 @@ namespace JoinMonster.Tests.Unit.Resolvers
         {
             var source = new Dictionary<string, object>
             {
-                {"name", "Jacket"}
+                {"productName#name", "Jacket"}
             };
 
             var context = new ResolveFieldContext

--- a/test/JoinMonster.Tests.Unit/Stubs/StubExecutionStrategy.cs
+++ b/test/JoinMonster.Tests.Unit/Stubs/StubExecutionStrategy.cs
@@ -30,6 +30,7 @@ namespace JoinMonster.Tests.Unit.Stubs
                 Operation = document.OperationWithName(string.Empty)!,
                 Variables = variables ?? new Variables(),
                 Errors = new ExecutionErrors(),
+                ExecutionStrategy = this,
             };
 
             var rootType = GetOperationRootType(context);


### PR DESCRIPTION
Use a combination of field alias and field name when generating internal field name used when converting to sql to allow for the same field being aliased and having different arguments